### PR TITLE
Move string to int64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,6 +154,8 @@ add_library(oatpp
         oatpp/web/client/HttpRequestExecutor.hpp
         oatpp/web/client/RequestExecutor.cpp
         oatpp/web/client/RequestExecutor.hpp
+        oatpp/web/client/RetryPolicy.cpp
+        oatpp/web/client/RetryPolicy.hpp
         oatpp/web/mime/multipart/FileStreamProvider.cpp
         oatpp/web/mime/multipart/FileStreamProvider.hpp
         oatpp/web/mime/multipart/InMemoryPartReader.cpp

--- a/src/oatpp/core/async/Coroutine.hpp
+++ b/src/oatpp/core/async/Coroutine.hpp
@@ -505,11 +505,41 @@ public:
   AbstractCoroutine* getParent() const;
 
   /**
+   * Convenience method to generate Action of `type == Action::TYPE_REPEAT`.
+   * @return - repeat Action.
+   */
+  static Action repeat();
+
+  /**
+   * Convenience method to generate Action of `type == Action::TYPE_WAIT_REPEAT`.
+   * @return - TYPE_WAIT_REPEAT Action.
+   */
+  static Action waitRepeat(const std::chrono::duration<v_int64, std::micro>& timeout);
+
+  /**
+   * Wait asynchronously for the specified time.
+   * @return - repeat Action.
+   */
+  CoroutineStarter waitFor(const std::chrono::duration<v_int64, std::micro>& timeout);
+
+  /**
+   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
+   * @return - TYPE_WAIT_FOR_IO Action.
+   */
+  static Action ioWait(data::v_io_handle ioHandle, Action::IOEventType ioEventType);
+
+  /**
+   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
+   * @return - TYPE_IO_REPEAT Action.
+   */
+  static Action ioRepeat(data::v_io_handle ioHandle, Action::IOEventType ioEventType);
+
+  /**
    * Convenience method to generate error reporting Action.
    * @param error - &id:oatpp:async::Error;.
    * @return - error reporting Action.
    */
-  Action error(Error* error);
+  static Action error(Error* error);
 
   /**
    * Convenience method to generate error reporting Action.
@@ -577,41 +607,6 @@ public:
    */
   Action yieldTo(const Function& function) const {
     return Action(static_cast<FunctionPtr>(function));
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_REPEAT`.
-   * @return - repeat Action.
-   */
-  Action repeat() const {
-    return Action::createActionByType(Action::TYPE_REPEAT);
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_WAIT_REPEAT`.
-   * @return - TYPE_WAIT_REPEAT Action.
-   */
-  Action waitRepeat(const std::chrono::duration<v_int64, std::micro>& timeout) const {
-    auto startTime = std::chrono::system_clock::now();
-    auto end = startTime + timeout;
-    std::chrono::microseconds ms = std::chrono::duration_cast<std::chrono::microseconds>(end.time_since_epoch());
-    return Action::createWaitRepeatAction(ms.count());
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
-   * @return - TYPE_WAIT_FOR_IO Action.
-   */
-  Action ioWait(data::v_io_handle ioHandle, Action::IOEventType ioEventType) const {
-    return Action::createIOWaitAction(ioHandle, ioEventType);
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
-   * @return - TYPE_IO_REPEAT Action.
-   */
-  Action ioRepeat(data::v_io_handle ioHandle, Action::IOEventType ioEventType) const {
-    return Action::createIORepeatAction(ioHandle, ioEventType);
   }
 
   /**
@@ -764,41 +759,6 @@ public:
    */
   Action yieldTo(const Function& function) const {
     return Action(static_cast<AbstractCoroutine::FunctionPtr>(function));
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_WAIT_REPEAT`.
-   * @return - TYPE_WAIT_REPEAT Action.
-   */
-  Action waitRepeat(const std::chrono::duration<v_int64, std::micro>& timeout) const {
-    auto startTime = std::chrono::system_clock::now();
-    auto end = startTime + timeout;
-    std::chrono::microseconds ms = std::chrono::duration_cast<std::chrono::microseconds>(end.time_since_epoch());
-    return Action::createWaitRepeatAction(ms.count());
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
-   * @return - TYPE_WAIT_FOR_IO Action.
-   */
-  Action ioWait(data::v_io_handle ioHandle, Action::IOEventType ioEventType) const {
-    return Action::createIOWaitAction(ioHandle, ioEventType);
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_IO_WAIT`.
-   * @return - TYPE_IO_REPEAT Action.
-   */
-  Action ioRepeat(data::v_io_handle ioHandle, Action::IOEventType ioEventType) const {
-    return Action::createIORepeatAction(ioHandle, ioEventType);
-  }
-
-  /**
-   * Convenience method to generate Action of `type == Action::TYPE_REPEAT`.
-   * @return - repeat Action.
-   */
-  Action repeat() const {
-    return Action::createActionByType(Action::TYPE_REPEAT);
   }
 
   /**

--- a/src/oatpp/core/base/Environment.hpp
+++ b/src/oatpp/core/base/Environment.hpp
@@ -70,6 +70,8 @@ typedef v_float32* p_float32;
 typedef std::atomic_int_fast64_t v_atomicCounter;
 typedef v_int64 v_counter;
 
+typedef intptr_t v_buff_size;
+
 namespace oatpp { namespace base{
 
 /**

--- a/src/oatpp/core/base/StrBuffer.cpp
+++ b/src/oatpp/core/base/StrBuffer.cpp
@@ -28,13 +28,13 @@
 
 namespace oatpp { namespace base {
   
-void StrBuffer::set(const void* data, v_int64 size, bool hasOwnData) {
+void StrBuffer::set(const void* data, v_buff_size size, bool hasOwnData) {
   m_data = (p_char8) data;
   m_size = size;
   m_hasOwnData = hasOwnData;
 }
   
-void StrBuffer::setAndCopy(const void* data, const void* originData, v_int64 size){
+void StrBuffer::setAndCopy(const void* data, const void* originData, v_buff_size size){
   m_data = (p_char8) data;
   m_size = size;
   //m_hasOwnData = false;
@@ -44,7 +44,7 @@ void StrBuffer::setAndCopy(const void* data, const void* originData, v_int64 siz
   m_data[size] = 0;
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_int64 size, bool copyAsOwnData) {
+std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_buff_size size, bool copyAsOwnData) {
   if(copyAsOwnData) {
     memory::AllocationExtras extras(size + 1);
     std::shared_ptr<StrBuffer> ptr;
@@ -59,7 +59,7 @@ std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_int64 size
   return std::make_shared<StrBuffer>(data, size, copyAsOwnData);
 }
   
-p_char8 StrBuffer::allocStrBuffer(const void* originData, v_int64 size, bool copyAsOwnData) {
+p_char8 StrBuffer::allocStrBuffer(const void* originData, v_buff_size size, bool copyAsOwnData) {
   if(copyAsOwnData) {
     p_char8 data = new v_char8[size + 1];
     data[size] = 0;
@@ -77,7 +77,7 @@ StrBuffer::StrBuffer()
   , m_hasOwnData(false)
 {}
 
-StrBuffer::StrBuffer(const void* data, v_int64 size, bool copyAsOwnData)
+StrBuffer::StrBuffer(const void* data, v_buff_size size, bool copyAsOwnData)
   : m_data(allocStrBuffer(data, size, copyAsOwnData))
   , m_size(size)
   , m_hasOwnData(copyAsOwnData)
@@ -90,23 +90,23 @@ StrBuffer::~StrBuffer() {
   m_data = nullptr;
 }
   
-std::shared_ptr<StrBuffer> StrBuffer::createShared(const void* data, v_int64 size, bool copyAsOwnData) {
+std::shared_ptr<StrBuffer> StrBuffer::createShared(const void* data, v_buff_size size, bool copyAsOwnData) {
   return allocShared(data, size, copyAsOwnData);
 }
   
 std::shared_ptr<StrBuffer> StrBuffer::createShared(const char* data, bool copyAsOwnData) {
-  return allocShared(data, (v_int64) std::strlen(data), copyAsOwnData);
+  return allocShared(data, std::strlen(data), copyAsOwnData);
 }
 
 std::shared_ptr<StrBuffer> StrBuffer::createShared(StrBuffer* other, bool copyAsOwnData) {
   return allocShared(other->getData(), other->getSize(), copyAsOwnData);
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::createShared(v_int64 size) {
+std::shared_ptr<StrBuffer> StrBuffer::createShared(v_buff_size size) {
   return allocShared(nullptr, size, true);
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::createSharedConcatenated(const void* data1, v_int64 size1, const void* data2, v_int64 size2) {
+std::shared_ptr<StrBuffer> StrBuffer::createSharedConcatenated(const void* data1, v_buff_size size1, const void* data2, v_buff_size size2) {
   const auto& ptr = allocShared(nullptr, size1 + size2, true);
   std::memcpy(ptr->m_data, data1, size1);
   std::memcpy(ptr->m_data + size1, data2, size2);
@@ -136,7 +136,7 @@ p_char8 StrBuffer::getData() const {
   return m_data;
 }
 
-v_int64 StrBuffer::getSize() const {
+v_buff_size StrBuffer::getSize() const {
   return m_size;
 }
 
@@ -164,7 +164,7 @@ std::shared_ptr<StrBuffer> StrBuffer::toUpperCase() const {
   return ptr;
 }
   
-bool StrBuffer::equals(const void* data, v_int64 size) const {
+bool StrBuffer::equals(const void* data, v_buff_size size) const {
   if(m_size == size) {
     return equals(m_data, data, size);
   }
@@ -172,7 +172,7 @@ bool StrBuffer::equals(const void* data, v_int64 size) const {
 }
 
 bool StrBuffer::equals(const char* data) const {
-  if(m_size ==  std::strlen(data)) {
+  if(m_size == std::strlen(data)) {
     return equals(m_data, data, m_size);
   }
   return false;
@@ -182,7 +182,7 @@ bool StrBuffer::equals(StrBuffer* other) const {
   return equals((StrBuffer*) this, other);
 }
 
-bool StrBuffer::startsWith(const void* data, v_int64 size) const {
+bool StrBuffer::startsWith(const void* data, v_buff_size size) const {
   if(m_size >= size) {
     return equals(m_data, data, size);
   }
@@ -190,7 +190,7 @@ bool StrBuffer::startsWith(const void* data, v_int64 size) const {
 }
 
 bool StrBuffer::startsWith(const char* data) const {
-  v_int64 length = std::strlen(data);
+  v_buff_size length = std::strlen(data);
   if(m_size >= length) {
     return equals(m_data, data, length);
   }
@@ -206,11 +206,11 @@ bool StrBuffer::startsWith(StrBuffer* data) const {
 
 // static
   
-v_int64 StrBuffer::compare(const void* data1, const void* data2, v_int64 size) {
+v_buff_size StrBuffer::compare(const void* data1, const void* data2, v_buff_size size) {
   return std::memcmp(data1, data2, size);
 }
 
-v_int64 StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
+v_buff_size StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
   if(str1 == str2) {
     return 0;
   }
@@ -221,14 +221,14 @@ v_int64 StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
   }
 }
 
-bool StrBuffer::equals(const void* data1, const void* data2, v_int64 size) {
+bool StrBuffer::equals(const void* data1, const void* data2, v_buff_size size) {
   return (data1 == data2) || (std::memcmp(data1, data2, size) == 0);
 }
   
 bool StrBuffer::equals(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int64 size = std::strlen(data1);
+  v_buff_size size = std::strlen(data1);
   return (size == std::strlen(data2) && std::memcmp(data1, data2, size) == 0);
 }
   
@@ -239,8 +239,8 @@ bool StrBuffer::equals(StrBuffer* str1, StrBuffer* str2) {
           );
 }
 
-bool StrBuffer::equalsCI(const void* data1, const void* data2, v_int64 size) {
-  for(v_int64 i = 0; i < size; i++) {
+bool StrBuffer::equalsCI(const void* data1, const void* data2, v_buff_size size) {
+  for(v_buff_size i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data1) [i];
     v_char8 b = ((p_char8) data2) [i];
     if(a >= 'A' && a <= 'Z') a |= 32;
@@ -255,7 +255,7 @@ bool StrBuffer::equalsCI(const void* data1, const void* data2, v_int64 size) {
 bool StrBuffer::equalsCI(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int64 size = std::strlen(data1);
+  v_buff_size size = std::strlen(data1);
   return (size == std::strlen(data2) && equalsCI(data1, data2, size) == 0);
 }
   
@@ -266,8 +266,8 @@ bool StrBuffer::equalsCI(StrBuffer* str1, StrBuffer* str2) {
           );
 }
 
-bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_int64 size) {
-  for(v_int64 i = 0; i < size; i++) {
+bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_buff_size size) {
+  for(v_buff_size i = 0; i < size; i++) {
     if((((p_char8) data1) [i] | 32) != (((p_char8) data2) [i] | 32)) {
       return false;
     }
@@ -278,7 +278,7 @@ bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_int64 size
 bool StrBuffer::equalsCI_FAST(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int64 size = std::strlen(data1);
+  v_buff_size size = std::strlen(data1);
   return (size == std::strlen(data2) && equalsCI_FAST(data1, data2, size) == 0);
 }
 
@@ -290,19 +290,19 @@ bool StrBuffer::equalsCI_FAST(StrBuffer* str1, StrBuffer* str2) {
 }
   
 bool StrBuffer::equalsCI_FAST(StrBuffer* str1, const char* str2) {
-  v_int64 len = std::strlen(str2);
+  v_buff_size len = std::strlen(str2);
   return (str1->getSize() == len && equalsCI_FAST(str1->m_data, str2, str1->m_size));
 }
 
-void StrBuffer::lowerCase(const void* data, v_int64 size) {
-  for(v_int64 i = 0; i < size; i++) {
+void StrBuffer::lowerCase(const void* data, v_buff_size size) {
+  for(v_buff_size i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data)[i];
     if(a >= 'A' && a <= 'Z') ((p_char8) data)[i] = a | 32;
   }
 }
 
-void StrBuffer::upperCase(const void* data, v_int64 size) {
-  for(v_int64 i = 0; i < size; i++) {
+void StrBuffer::upperCase(const void* data, v_buff_size size) {
+  for(v_buff_size i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data)[i];
     if(a >= 'a' && a <= 'z') ((p_char8) data)[i] = a & 223;
   }

--- a/src/oatpp/core/base/StrBuffer.hpp
+++ b/src/oatpp/core/base/StrBuffer.hpp
@@ -38,39 +38,39 @@ namespace oatpp { namespace base {
 class StrBuffer : public oatpp::base::Countable {  
 private:
 
-  static constexpr v_int64 SM_STRING_POOL_ENTRY_SIZE = 256;
+  static constexpr v_buff_size SM_STRING_POOL_ENTRY_SIZE = 256;
   
   static oatpp::base::memory::ThreadDistributedMemoryPool& getSmallStringPool() {
     static oatpp::base::memory::ThreadDistributedMemoryPool pool("Small_String_Pool", SM_STRING_POOL_ENTRY_SIZE, 16);
     return pool;
   }
   
-  static v_int64 getSmStringBaseSize() {
+  static v_buff_size getSmStringBaseSize() {
     memory::AllocationExtras extras(0);
     auto ptr = memory::customPoolAllocateSharedWithExtras<StrBuffer>(extras, getSmallStringPool());
     return extras.baseSize;
   }
   
-  static v_int64 getSmStringSize() {
-    static v_int64 size = SM_STRING_POOL_ENTRY_SIZE - getSmStringBaseSize();
+  static v_buff_size getSmStringSize() {
+    static v_buff_size size = SM_STRING_POOL_ENTRY_SIZE - getSmStringBaseSize();
     return size;
   }
 
 private:
   p_char8 m_data;
-  v_int64 m_size;
+  v_buff_size m_size;
   bool m_hasOwnData;
 private:
   
-  void set(const void* data, v_int64 size, bool hasOwnData);
-  void setAndCopy(const void* data, const void* originData, v_int64 size);
-  static std::shared_ptr<StrBuffer> allocShared(const void* data, v_int64 size, bool copyAsOwnData);
+  void set(const void* data, v_buff_size size, bool hasOwnData);
+  void setAndCopy(const void* data, const void* originData, v_buff_size size);
+  static std::shared_ptr<StrBuffer> allocShared(const void* data, v_buff_size size, bool copyAsOwnData);
 
   /*
    * Allocate memory for string or use originData<br>
    * if copyAsOwnData == false return originData
    */
-  static p_char8 allocStrBuffer(const void* originData, v_int64 size, bool copyAsOwnData);
+  static p_char8 allocStrBuffer(const void* originData, v_buff_size size, bool copyAsOwnData);
   
 public:
   /**
@@ -84,7 +84,7 @@ public:
    * @param size - size of the data.
    * @param copyAsOwnData - if true then allocate own buffer and copy data to that buffer.
    */
-  StrBuffer(const void* data, v_int64 size, bool copyAsOwnData);
+  StrBuffer(const void* data, v_buff_size size, bool copyAsOwnData);
 public:
 
   /**
@@ -97,7 +97,7 @@ public:
    * @param size - size of the buffer.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createShared(v_int64 size);
+  static std::shared_ptr<StrBuffer> createShared(v_buff_size size);
 
   /**
    * Create shared StrBuffer with data, size, and copyAsOwnData parameters.
@@ -106,7 +106,7 @@ public:
    * @param copyAsOwnData - if true then allocate own buffer and copy data to that buffer.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createShared(const void* data, v_int64 size, bool copyAsOwnData = true);
+  static std::shared_ptr<StrBuffer> createShared(const void* data, v_buff_size size, bool copyAsOwnData = true);
 
   /**
    * Create shared StrBuffer with data, and copyAsOwnData parameters.
@@ -132,7 +132,7 @@ public:
    * @param size2 - size of the data2.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createSharedConcatenated(const void* data1, v_int64 size1, const void* data2, v_int64 size2);
+  static std::shared_ptr<StrBuffer> createSharedConcatenated(const void* data1, v_buff_size size1, const void* data2, v_buff_size size2);
 
   /**
    * Create shared StrBuffer from c-string.
@@ -170,7 +170,7 @@ public:
    * Get buffer size.
    * @return - buffer size.
    */
-  v_int64 getSize() const;
+  v_buff_size getSize() const;
 
   /**
    * Get pointer to data of the buffer as `const* char`.
@@ -210,7 +210,7 @@ public:
    * @param size - size of the data.
    * @return - true if all chars of buffer are same as in data, and size == this.getSize().
    */
-  bool equals(const void* data, v_int64 size) const;
+  bool equals(const void* data, v_buff_size size) const;
 
   /**
    * Check string equality of the buffer to data of specified size.
@@ -232,7 +232,7 @@ public:
    * @param size - size of the data.
    * @return - true if buffer starts with specified data.
    */
-  bool startsWith(const void* data, v_int64 size) const;
+  bool startsWith(const void* data, v_buff_size size) const;
 
   /**
    * Check if buffer starts with specified data.
@@ -260,7 +260,7 @@ public:
    * ​0​ if all count bytes of data1 and data2 are equal.<br>
    * Positive value if the first differing byte in data1 is greater than the corresponding byte in data2.
    */
-  static v_int64 compare(const void* data1, const void* data2, v_int64 size);
+  static v_buff_size compare(const void* data1, const void* data2, v_buff_size size);
 
   /**
    * Compare data1, data2 using `std::memcmp`.
@@ -270,7 +270,7 @@ public:
    * ​0​ if all count bytes of data1 and data2 are equal.<br>
    * Positive value if the first differing byte in data1 is greater than the corresponding byte in data2.
    */
-  static v_int64 compare(StrBuffer* data1, StrBuffer* data2);
+  static v_buff_size compare(StrBuffer* data1, StrBuffer* data2);
 
   /**
    * Check string equality of data1 to data2.
@@ -279,7 +279,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equals(const void* data1, const void* data2, v_int64 size);
+  static bool equals(const void* data1, const void* data2, v_buff_size size);
 
   /**
    * Check string equality of data1 to data2.
@@ -304,7 +304,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equalsCI(const void* data1, const void* data2, v_int64 size);
+  static bool equalsCI(const void* data1, const void* data2, v_buff_size size);
 
   /**
    * Check Case Insensitive string equality of data1 to data2.
@@ -329,7 +329,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equalsCI_FAST(const void* data1, const void* data2, v_int64 size);
+  static bool equalsCI_FAST(const void* data1, const void* data2, v_buff_size size);
 
   /**
    * Check Case Insensitive string equality of data1 to data2. (ASCII only, correct compare if one of strings contains letters only)
@@ -360,14 +360,14 @@ public:
    * @param data - pointer to data.
    * @param size - size of the data.
    */
-  static void lowerCase(const void* data, v_int64 size);
+  static void lowerCase(const void* data, v_buff_size size);
 
   /**
    * Change characters in data to uppercase.
    * @param data - pointer to data.
    * @param size - size of the data.
    */
-  static void upperCase(const void* data, v_int64 size);
+  static void upperCase(const void* data, v_buff_size size);
   
 };
   

--- a/src/oatpp/core/base/memory/Allocator.cpp
+++ b/src/oatpp/core/base/memory/Allocator.cpp
@@ -26,7 +26,7 @@
 
 namespace oatpp { namespace base { namespace memory {
 
-AllocatorPoolInfo::AllocatorPoolInfo(const char* pPoolName, v_int64 pPoolChunkSize)
+AllocatorPoolInfo::AllocatorPoolInfo(const char* pPoolName, v_buff_size pPoolChunkSize)
   : poolName(pPoolName)
   , poolChunkSize(pPoolChunkSize)
 {}

--- a/src/oatpp/core/base/memory/Allocator.hpp
+++ b/src/oatpp/core/base/memory/Allocator.hpp
@@ -40,7 +40,7 @@ public:
    * @param pPoolName - memory pool name.
    * @param pPoolChunkSize - memory pool chunk size. For more about chunk size see &id:oatpp::base::memory::MemoryPool::MemoryPool;.
    */
-  AllocatorPoolInfo(const char* pPoolName, v_int64 pPoolChunkSize);
+  AllocatorPoolInfo(const char* pPoolName, v_buff_size pPoolChunkSize);
 
   /**
    * Memory pool name.
@@ -51,7 +51,7 @@ public:
    * Memory pool chunk size.
    * For more about chunk size see &id:oatpp::base::memory::MemoryPool::MemoryPool;.
    */
-  const v_int64 poolChunkSize;
+  const v_buff_size poolChunkSize;
 };
 
 /**
@@ -160,12 +160,12 @@ inline bool operator != (const ThreadLocalPoolSharedObjectAllocator<T>& a, const
  */
 class AllocationExtras {
 public:
-  AllocationExtras(v_int64 pExtraWanted)
+  AllocationExtras(v_buff_size pExtraWanted)
     : extraWanted(pExtraWanted)
   {}
-  const v_int64 extraWanted;
+  const v_buff_size extraWanted;
   void* extraPtr;
-  v_int64 baseSize;
+  v_buff_size baseSize;
 };
 
 /**

--- a/src/oatpp/core/base/memory/MemoryPool.cpp
+++ b/src/oatpp/core/base/memory/MemoryPool.cpp
@@ -30,7 +30,7 @@
 
 namespace oatpp { namespace base { namespace  memory {
 
-MemoryPool::MemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize)
+MemoryPool::MemoryPool(const std::string& name, v_buff_size entrySize, v_buff_size chunkSize)
   : m_name(name)
   , m_entrySize(entrySize)
   , m_chunkSize(chunkSize)
@@ -58,11 +58,11 @@ void MemoryPool::allocChunk() {
 #ifdef OATPP_DISABLE_POOL_ALLOCATIONS
   // DO NOTHING
 #else
-  v_int64 entryBlockSize = sizeof(EntryHeader) + m_entrySize;
-  v_int64 chunkMemSize = entryBlockSize * m_chunkSize;
+  v_buff_size entryBlockSize = sizeof(EntryHeader) + m_entrySize;
+  v_buff_size chunkMemSize = entryBlockSize * m_chunkSize;
   p_char8 mem = new v_char8[chunkMemSize];
   m_chunks.push_back(mem);
-  for(v_int64 i = 0; i < m_chunkSize; i++){
+  for(v_buff_size i = 0; i < m_chunkSize; i++){
     EntryHeader* entry = new (mem + i * entryBlockSize) EntryHeader(this, m_id, m_rootEntry);
     m_rootEntry = entry;
   }
@@ -118,11 +118,11 @@ std::string MemoryPool::getName(){
   return m_name;
 }
 
-v_int64 MemoryPool::getEntrySize(){
+v_buff_size MemoryPool::getEntrySize(){
   return m_entrySize;
 }
 
-v_int64 MemoryPool::getSize(){
+v_buff_size MemoryPool::getSize(){
   return m_chunks.size() * m_chunkSize;
 }
 
@@ -137,7 +137,7 @@ std::atomic<v_int64> MemoryPool::poolIdCounter(0);
 const v_int64 ThreadDistributedMemoryPool::SHARDS_COUNT_DEFAULT = OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT;
 
 #if defined(OATPP_DISABLE_POOL_ALLOCATIONS) || defined(OATPP_COMPAT_BUILD_NO_THREAD_LOCAL)
-ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize, v_int64 shardsCount)
+ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_buff_size entrySize, v_buff_size chunkSize, v_int64 shardsCount)
   : m_shardsCount(1)
   , m_shards(new MemoryPool*[1])
   , m_deleted(false)
@@ -147,7 +147,7 @@ ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name
   }
 }
 #else
-ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize, v_int64 shardsCount)
+ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_buff_size entrySize, v_buff_size chunkSize, v_int64 shardsCount)
   : m_shardsCount(shardsCount)
   , m_shards(new MemoryPool*[m_shardsCount])
   , m_deleted(false)

--- a/src/oatpp/core/base/memory/MemoryPool.hpp
+++ b/src/oatpp/core/base/memory/MemoryPool.hpp
@@ -66,8 +66,8 @@ private:
   void freeByEntryHeader(EntryHeader* entry);
 private:
   std::string m_name;
-  v_int64 m_entrySize;
-  v_int64 m_chunkSize;
+  v_buff_size m_entrySize;
+  v_buff_size m_chunkSize;
   v_int64 m_id;
   std::list<p_char8> m_chunks;
   EntryHeader* m_rootEntry;
@@ -81,7 +81,7 @@ public:
    * @param entrySize - size of the entry in bytes returned in call to &l:MemoryPool::obtain ();.
    * @param chunkSize - number of entries in one chunk.
    */
-  MemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize);
+  MemoryPool(const std::string& name, v_buff_size entrySize, v_buff_size chunkSize);
 
   /**
    * Deleted copy-constructor.
@@ -117,13 +117,13 @@ public:
    * Get size of the memory entry in bytes which can be obtained by call to &l:MemoryPool::obtain ();.
    * @return - size of the enrty in bytes.
    */
-  v_int64 getEntrySize();
+  v_buff_size getEntrySize();
 
   /**
    * Get size of the memory allocated by memory pool.
    * @return - size of the memory allocated by memory pool.
    */
-  v_int64 getSize();
+  v_buff_size getSize();
 
   /**
    * Get number of entries currently in use.
@@ -156,7 +156,7 @@ public:
    * @param chunkSize - number of entries in chunk.
    * @param shardsCount - number of MemoryPools (&l:MemoryPool;) "shards" to create.
    */
-  ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize,
+  ThreadDistributedMemoryPool(const std::string& name, v_buff_size entrySize, v_buff_size chunkSize,
                               v_int64 shardsCount = SHARDS_COUNT_DEFAULT);
 
   /**
@@ -197,13 +197,13 @@ private:
   
   void grow(){
     
-    v_int64 newSize = m_size + m_growSize;
+    v_buff_size newSize = m_size + m_growSize;
     T** newIndex = new T*[newSize];
     std::memcpy(newIndex, m_index, m_size);
     
     Block* b = new Block(new v_char8 [m_growSize * sizeof(T)], m_blocks);
     m_blocks = b;
-    for(v_int64 i = 0; i < m_growSize; i++) {
+    for(v_buff_size i = 0; i < m_growSize; i++) {
       newIndex[m_size + i] = (T*) (&b->memory[i * sizeof(T)]);
     }
     
@@ -214,9 +214,9 @@ private:
   }
   
 private:
-  v_int64 m_growSize;
-  v_int64 m_size;
-  v_int64 m_indexPosition;
+  v_buff_size m_growSize;
+  v_buff_size m_size;
+  v_buff_size m_indexPosition;
   Block* m_blocks;
   T** m_index;
 public:
@@ -225,7 +225,7 @@ public:
    * Constructor.
    * @param growSize - number of objects to allocate when no free objects left.
    */
-  Bench(v_int64 growSize)
+  Bench(v_buff_size growSize)
     : m_growSize(growSize)
     , m_size(0)
     , m_indexPosition(0)

--- a/src/oatpp/core/data/buffer/FIFOBuffer.cpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.cpp
@@ -67,7 +67,7 @@ data::v_io_size FIFOBuffer::getBufferSize() const {
   return m_bufferSize;
 }
 
-data::v_io_size FIFOBuffer::read(void *data, data::v_io_size count) {
+data::v_io_size FIFOBuffer::read(void *data, v_buff_size count) {
   
   if(!m_canRead) {
     return data::IOError::WAIT_RETRY;
@@ -116,7 +116,7 @@ data::v_io_size FIFOBuffer::read(void *data, data::v_io_size count) {
   
 }
 
-data::v_io_size FIFOBuffer::peek(void *data, data::v_io_size count) {
+data::v_io_size FIFOBuffer::peek(void *data, v_buff_size count) {
 
   if(!m_canRead) {
     return data::IOError::WAIT_RETRY;
@@ -156,7 +156,7 @@ data::v_io_size FIFOBuffer::peek(void *data, data::v_io_size count) {
 
 }
 
-data::v_io_size FIFOBuffer::commitReadOffset(data::v_io_size count) {
+data::v_io_size FIFOBuffer::commitReadOffset(v_buff_size count) {
 
   if(!m_canRead) {
     return data::IOError::WAIT_RETRY;
@@ -201,7 +201,7 @@ data::v_io_size FIFOBuffer::commitReadOffset(data::v_io_size count) {
 
 }
 
-data::v_io_size FIFOBuffer::write(const void *data, data::v_io_size count) {
+data::v_io_size FIFOBuffer::write(const void *data, v_buff_size count) {
   
   if(m_canRead && m_writePosition == m_readPosition) {
     return data::IOError::WAIT_RETRY;
@@ -246,7 +246,7 @@ data::v_io_size FIFOBuffer::write(const void *data, data::v_io_size count) {
   
 }
 
-data::v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, data::v_io_size count) {
+data::v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count) {
 
   if(!m_canRead) {
     return data::IOError::WAIT_RETRY;
@@ -299,7 +299,7 @@ data::v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* str
 
 }
 
-data::v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::InputStream* stream, data::v_io_size count) {
+data::v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count) {
 
   if(m_canRead && m_writePosition == m_readPosition) {
     return data::IOError::WAIT_RETRY;
@@ -456,12 +456,12 @@ data::v_io_size SynchronizedFIFOBuffer::availableToWrite() {
   return m_fifo.availableToWrite();
 }
 
-data::v_io_size SynchronizedFIFOBuffer::read(void *data, data::v_io_size count) {
+data::v_io_size SynchronizedFIFOBuffer::read(void *data, v_buff_size count) {
   std::lock_guard<oatpp::concurrency::SpinLock> lock(m_lock);
   return m_fifo.read(data, count);
 }
 
-data::v_io_size SynchronizedFIFOBuffer::write(const void *data, data::v_io_size count) {
+data::v_io_size SynchronizedFIFOBuffer::write(const void *data, v_buff_size count) {
   std::lock_guard<oatpp::concurrency::SpinLock> lock(m_lock);
   return m_fifo.write(data, count);
 }

--- a/src/oatpp/core/data/buffer/FIFOBuffer.hpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.hpp
@@ -39,9 +39,9 @@ namespace oatpp { namespace data { namespace buffer {
 class FIFOBuffer {
 private:
   p_char8 m_buffer;
-  v_io_size m_bufferSize;
-  data::v_io_size m_readPosition;
-  data::v_io_size m_writePosition;
+  v_buff_size m_bufferSize;
+  v_buff_size m_readPosition;
+  v_buff_size m_writePosition;
   bool m_canRead;
 public:
 
@@ -91,7 +91,7 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size read(void *data, data::v_io_size count);
+  data::v_io_size read(void *data, v_buff_size count);
 
   /**
    * Peek up to count of bytes int he buffer
@@ -99,14 +99,14 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size peek(void *data, data::v_io_size count);
+  data::v_io_size peek(void *data, v_buff_size count);
 
   /**
    * Commit read offset
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size commitReadOffset(data::v_io_size count);
+  data::v_io_size commitReadOffset(v_buff_size count);
 
   /**
    * write up to count bytes from data to buffer
@@ -114,7 +114,7 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size write(const void *data, data::v_io_size count);
+  data::v_io_size write(const void *data, v_buff_size count);
 
   /**
    * call read and then write bytes read to output stream
@@ -122,7 +122,7 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size readAndWriteToStream(data::stream::OutputStream* stream, data::v_io_size count);
+  data::v_io_size readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count);
 
   /**
    * call stream.read() and then write bytes read to buffer
@@ -130,7 +130,7 @@ public:
    * @param count
    * @return
    */
-  data::v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, data::v_io_size count);
+  data::v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count);
 
   /**
    * flush all availableToRead bytes to stream
@@ -198,7 +198,7 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size read(void *data, data::v_io_size count);
+  data::v_io_size read(void *data, v_buff_size count);
 
   /**
    * write up to count bytes from data to buffer
@@ -206,7 +206,7 @@ public:
    * @param count
    * @return [1..count], IOErrors.
    */
-  data::v_io_size write(const void *data, data::v_io_size count);
+  data::v_io_size write(const void *data, v_buff_size count);
 
   /* No implementation of other methods */
   /* User should implement his own synchronization for other methods */

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -31,8 +31,6 @@
 #include "oatpp/core/base/Countable.hpp"
 #include "oatpp/core/base/StrBuffer.hpp"
 
-
-
 namespace oatpp { namespace data { namespace mapping { namespace type {
   
 namespace __class {
@@ -58,15 +56,15 @@ public:
   
   String() {}
   
-  String(v_int64 size)
+  String(v_buff_size size)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createShared(size))
   {}
   
-  String(const char* data, v_int64 size, bool copyAsOwnData = true)
+  String(const char* data, v_buff_size size, bool copyAsOwnData = true)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createShared(data, size, copyAsOwnData))
   {}
   
-  String(const char* data1, v_int64 size1, const char* data2, v_int64 size2)
+  String(const char* data1, v_buff_size size1, const char* data2, v_buff_size size2)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createSharedConcatenated(data1, size1, data2, size2))
   {}
   
@@ -420,16 +418,16 @@ namespace std {
     result_type operator()(oatpp::data::mapping::type::String const& s) const noexcept {
       
       p_char8 data = s->getData();
-      v_int64 size4 = s->getSize() >> 2;
+      v_buff_size size4 = s->getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int64 i = 0; i < size4; i++) {
+      for(v_buff_size i = 0; i < size4; i++) {
         result ^= *((p_word32) data);
         data += 4;
       }
       
-      for(v_int64 i = 0; i < s->getSize() - (size4 << 2); i++ ) {
+      for(v_buff_size i = 0; i < s->getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= data[i];
       }
       

--- a/src/oatpp/core/data/share/MemoryLabel.cpp
+++ b/src/oatpp/core/data/share/MemoryLabel.cpp
@@ -28,13 +28,13 @@
 
 namespace oatpp { namespace data { namespace share {
 
-MemoryLabel::MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
+MemoryLabel::MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size)
   : m_memoryHandle(memHandle)
   , m_data(data)
   , m_size(size)
 {}
   
-StringKeyLabel::StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
+StringKeyLabel::StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
   
@@ -46,7 +46,7 @@ StringKeyLabel::StringKeyLabel(const oatpp::String& str)
   : oatpp::data::share::MemoryLabel(str.getPtr(), str->getData(), str->getSize())
 {}
   
-StringKeyLabelCI::StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
+StringKeyLabelCI::StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
 
@@ -58,7 +58,7 @@ StringKeyLabelCI::StringKeyLabelCI(const oatpp::String& str)
   : oatpp::data::share::MemoryLabel(str.getPtr(), str->getData(), str->getSize())
 {}
   
-StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
+StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
 

--- a/src/oatpp/core/data/share/MemoryLabel.hpp
+++ b/src/oatpp/core/data/share/MemoryLabel.hpp
@@ -39,7 +39,7 @@ class MemoryLabel {
 protected:
   mutable std::shared_ptr<base::StrBuffer> m_memoryHandle;
   mutable p_char8 m_data;
-  v_int64 m_size;
+  v_buff_size m_size;
 public:
 
   /**
@@ -63,7 +63,7 @@ public:
    * @param data - pointer to data.
    * @param size - size of the data in bytes.
    */
-  MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
+  MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size);
 
   /**
    * Get pointer to labeled data.
@@ -77,7 +77,7 @@ public:
    * Get data size.
    * @return - size of the data.
    */
-  v_int64 getSize() const {
+  v_buff_size getSize() const {
     return m_size;
   }
 
@@ -106,7 +106,7 @@ public:
    * @return - `true` if equals.
    */
   bool equals(const char* data) const {
-    v_int64 size = std::strlen(data);
+    v_buff_size size = std::strlen(data);
     return m_size == size && base::StrBuffer::equals(m_data, data, m_size);
   }
 
@@ -117,7 +117,7 @@ public:
    * @param size - data size.
    * @return - `true` if equals.
    */
-  bool equals(const void* data, v_int64 size) const {
+  bool equals(const void* data, v_buff_size size) const {
     return m_size == size && base::StrBuffer::equals(m_data, data, m_size);
   }
 
@@ -151,7 +151,7 @@ public:
   
   StringKeyLabel() : MemoryLabel() {};
   
-  StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
+  StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size);
   StringKeyLabel(const char* constText);
   StringKeyLabel(const oatpp::String& str);
   
@@ -173,7 +173,7 @@ public:
   
   StringKeyLabelCI() : MemoryLabel() {};
   
-  StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
+  StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size);
   StringKeyLabelCI(const char* constText);
   StringKeyLabelCI(const oatpp::String& str);
   
@@ -195,7 +195,7 @@ public:
 class StringKeyLabelCI_FAST : public MemoryLabel {
 public:
   
-  StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
+  StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_buff_size size);
   StringKeyLabelCI_FAST(const char* constText);
   StringKeyLabelCI_FAST(const oatpp::String& str);
   
@@ -222,16 +222,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabel const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int64 size4 = s.getSize() >> 2;
+      v_buff_size size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int64 i = 0; i < size4; i++) {
+      for(v_buff_size i = 0; i < size4; i++) {
         result ^= *((p_word32) data);
         data += 4;
       }
       
-      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_buff_size i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= data[i];
       }
       
@@ -248,16 +248,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabelCI const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int64 size4 = s.getSize() >> 2;
+      v_buff_size size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int64 i = 0; i < size4; i++) {
+      for(v_buff_size i = 0; i < size4; i++) {
         result ^= (*((p_word32) data) | 538976288); // 538976288 = 32 | (32 << 8) | (32 << 16) | (32 << 24);
         data += 4;
       }
       
-      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_buff_size i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= (data[i] | 32);
       }
       
@@ -274,16 +274,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabelCI_FAST const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int64 size4 = s.getSize() >> 2;
+      v_buff_size size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int64 i = 0; i < size4; i++) {
+      for(v_buff_size i = 0; i < size4; i++) {
         result ^= (*((p_word32) data) | 538976288); // 538976288 = 32 | (32 << 8) | (32 << 16) | (32 << 24);
         data += 4;
       }
       
-      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_buff_size i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= (data[i] | 32);
       }
       

--- a/src/oatpp/core/data/stream/BufferStream.cpp
+++ b/src/oatpp/core/data/stream/BufferStream.cpp
@@ -41,7 +41,7 @@ BufferOutputStream::~BufferOutputStream() {
   delete [] m_data;
 }
 
-data::v_io_size BufferOutputStream::write(const void *data, data::v_io_size count) {
+data::v_io_size BufferOutputStream::write(const void *data, v_buff_size count) {
 
   reserveBytesUpfront(count);
 
@@ -110,7 +110,7 @@ oatpp::String BufferOutputStream::toString() {
   return oatpp::String((const char*)m_data, m_position, true);
 }
 
-oatpp::String BufferOutputStream::getSubstring(data::v_io_size pos, data::v_io_size count) {
+oatpp::String BufferOutputStream::getSubstring(data::v_io_size pos, v_buff_size count) {
   if(pos + count <= m_position) {
     return oatpp::String((const char *) (m_data + pos), count, true);
   } else {
@@ -181,7 +181,7 @@ void BufferInputStream::reset() {
   m_position = 0;
 }
 
-data::v_io_size BufferInputStream::read(void *data, data::v_io_size count) {
+data::v_io_size BufferInputStream::read(void *data, v_buff_size count) {
   data::v_io_size desiredAmount = count;
   if(desiredAmount > m_size - m_position) {
     desiredAmount = m_size - m_position;

--- a/src/oatpp/core/data/stream/BufferStream.hpp
+++ b/src/oatpp/core/data/stream/BufferStream.hpp
@@ -58,7 +58,7 @@ public:
    * @param count - number of bytes to write.
    * @return - actual number of bytes written. &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   /**
    * Set stream I/O mode.
@@ -114,7 +114,7 @@ public:
    * @param count - size of bytes to write to substring.
    * @return - &id:oatpp::String;
    */
-  oatpp::String getSubstring(data::v_io_size pos, data::v_io_size count);
+  oatpp::String getSubstring(data::v_io_size pos, v_buff_size count);
 
   /**
    * Write all bytes from buffer to stream.
@@ -181,7 +181,7 @@ public:
    * @param count - size of the buffer.
    * @return - actual number of bytes read. 0 - designates end of the buffer.
    */
-  data::v_io_size read(void *data, data::v_io_size count) override;
+  data::v_io_size read(void *data, v_buff_size count) override;
 
   /**
    * In case of a `BufferInputStream` suggested Action is always &id:oatpp::async::Action::TYPE_REPEAT; if `ioResult` is greater then zero. <br>

--- a/src/oatpp/core/data/stream/ChunkedBuffer.cpp
+++ b/src/oatpp/core/data/stream/ChunkedBuffer.cpp
@@ -64,9 +64,10 @@ void ChunkedBuffer::freeEntry(ChunkEntry* entry){
 }
   
 data::v_io_size ChunkedBuffer::writeToEntry(ChunkEntry* entry,
-                                                      const void *data,
-                                                      data::v_io_size count,
-                                                      data::v_io_size& outChunkPos) {
+                                            const void *data,
+                                            v_buff_size count,
+                                            v_buff_size& outChunkPos)
+{
   if(count >= CHUNK_ENTRY_SIZE){
     std::memcpy(entry->chunk, data, CHUNK_ENTRY_SIZE);
     outChunkPos = 0;
@@ -79,10 +80,11 @@ data::v_io_size ChunkedBuffer::writeToEntry(ChunkEntry* entry,
 }
   
 data::v_io_size ChunkedBuffer::writeToEntryFrom(ChunkEntry* entry,
-                                                          data::v_io_size inChunkPos,
-                                                          const void *data,
-                                                          data::v_io_size count,
-                                                          data::v_io_size& outChunkPos) {
+                                                v_buff_size inChunkPos,
+                                                const void *data,
+                                                v_buff_size count,
+                                                v_buff_size& outChunkPos)
+{
   data::v_io_size spaceLeft = CHUNK_ENTRY_SIZE - inChunkPos;
   if(count >= spaceLeft){
     std::memcpy(&((p_char8) entry->chunk)[inChunkPos], data, (size_t)spaceLeft);
@@ -96,15 +98,16 @@ data::v_io_size ChunkedBuffer::writeToEntryFrom(ChunkEntry* entry,
 }
   
 ChunkedBuffer::ChunkEntry* ChunkedBuffer::getChunkForPosition(ChunkEntry* fromChunk,
-                                                                      data::v_io_size pos,
-                                                                      data::v_io_size& outChunkPos) {
-  
-  data::v_io_size segIndex = pos >> CHUNK_ENTRY_SIZE_INDEX_SHIFT;
+                                                              v_buff_size pos,
+                                                              v_buff_size& outChunkPos)
+{
+
+  v_buff_size segIndex = pos >> CHUNK_ENTRY_SIZE_INDEX_SHIFT;
   outChunkPos = pos - (segIndex << CHUNK_ENTRY_SIZE_INDEX_SHIFT);
   
   auto curr = fromChunk;
   
-  for(data::v_io_size i = 0; i < segIndex; i++){
+  for(v_buff_size i = 0; i < segIndex; i++){
     curr = curr->next;
   }
   
@@ -112,7 +115,7 @@ ChunkedBuffer::ChunkEntry* ChunkedBuffer::getChunkForPosition(ChunkEntry* fromCh
   
 }
   
-data::v_io_size ChunkedBuffer::write(const void *data, data::v_io_size count){
+data::v_io_size ChunkedBuffer::write(const void *data, v_buff_size count){
   
   if(count <= 0){
     return 0;
@@ -123,7 +126,7 @@ data::v_io_size ChunkedBuffer::write(const void *data, data::v_io_size count){
   }
   
   ChunkEntry* entry = m_lastEntry;
-  data::v_io_size pos = 0;
+  v_buff_size pos = 0;
   
   pos += writeToEntryFrom(entry, m_chunkPos, data, count, m_chunkPos);
   
@@ -154,32 +157,32 @@ IOMode ChunkedBuffer::getOutputStreamIOMode() {
 }
   
 data::v_io_size ChunkedBuffer::readSubstring(void *buffer,
-                                             data::v_io_size pos,
-                                             data::v_io_size count)
+                                             v_buff_size pos,
+                                             v_buff_size count)
 {
   
   if(pos < 0 || pos >= m_size){
     return 0;
   }
   
-  data::v_io_size countToRead;
+  v_buff_size countToRead;
   if(pos + count > m_size){
     countToRead = m_size - pos;
   } else {
     countToRead = count;
   }
-  
-  data::v_io_size firstChunkPos;
+
+  v_buff_size firstChunkPos;
   auto firstChunk = getChunkForPosition(m_firstEntry, pos, firstChunkPos);
-  
-  data::v_io_size lastChunkPos;
+
+  v_buff_size lastChunkPos;
   auto lastChunk = getChunkForPosition(firstChunk, firstChunkPos + countToRead, lastChunkPos);
   
   data::v_io_size bufferPos = 0;
   
   if(firstChunk != lastChunk){
     
-    data::v_io_size countToCopy = CHUNK_ENTRY_SIZE - firstChunkPos;
+    v_buff_size countToCopy = CHUNK_ENTRY_SIZE - firstChunkPos;
     std::memcpy(buffer, &((p_char8)firstChunk->chunk)[firstChunkPos], (size_t)countToCopy);
     bufferPos += countToCopy;
     
@@ -194,7 +197,7 @@ data::v_io_size ChunkedBuffer::readSubstring(void *buffer,
     std::memcpy(&((p_char8)buffer)[bufferPos], lastChunk->chunk, (size_t)lastChunkPos);
     
   } else {
-    data::v_io_size countToCopy = lastChunkPos - firstChunkPos;
+    v_buff_size countToCopy = lastChunkPos - firstChunkPos;
     std::memcpy(buffer, &((p_char8)firstChunk->chunk)[firstChunkPos], (size_t)countToCopy);
   }
   
@@ -202,7 +205,7 @@ data::v_io_size ChunkedBuffer::readSubstring(void *buffer,
   
 }
   
-oatpp::String ChunkedBuffer::getSubstring(data::v_io_size pos, data::v_io_size count){
+oatpp::String ChunkedBuffer::getSubstring(v_buff_size pos, v_buff_size count){
   auto str = oatpp::String((v_int32) count);
   readSubstring(str->getData(), pos, count);
   return str;
@@ -307,7 +310,7 @@ std::shared_ptr<ChunkedBuffer::Chunks> ChunkedBuffer::getChunks() {
   return chunks;
 }
 
-data::v_io_size ChunkedBuffer::getSize(){
+v_buff_size ChunkedBuffer::getSize(){
   return m_size;
 }
 

--- a/src/oatpp/core/data/stream/ChunkedBuffer.hpp
+++ b/src/oatpp/core/data/stream/ChunkedBuffer.hpp
@@ -89,7 +89,7 @@ public:
       , size(pSize)
     {}
     
-    static std::shared_ptr<Chunk> createShared(void* data, data::v_io_size size){
+    static std::shared_ptr<Chunk> createShared(void* data, v_buff_size size){
       return Shared_ChunkedBuffer_Chunk_Pool::allocateShared(data, size);
     }
     
@@ -101,9 +101,9 @@ public:
 public:
   typedef oatpp::collection::LinkedList<std::shared_ptr<Chunk>> Chunks;
 private:
-  
-  data::v_io_size m_size;
-  data::v_io_size m_chunkPos;
+
+  v_buff_size m_size;
+  v_buff_size m_chunkPos;
   ChunkEntry* m_firstEntry;
   ChunkEntry* m_lastEntry;
   IOMode m_ioMode;
@@ -114,19 +114,19 @@ private:
   void freeEntry(ChunkEntry* entry);
   
   data::v_io_size writeToEntry(ChunkEntry* entry,
-                                       const void *data,
-                                       data::v_io_size count,
-                                       data::v_io_size& outChunkPos);
+                               const void *data,
+                               v_buff_size count,
+                               v_buff_size& outChunkPos);
   
   data::v_io_size writeToEntryFrom(ChunkEntry* entry,
-                                           data::v_io_size inChunkPos,
-                                           const void *data,
-                                           data::v_io_size count,
-                                           data::v_io_size& outChunkPos);
+                                   v_buff_size inChunkPos,
+                                   const void *data,
+                                   v_buff_size count,
+                                   v_buff_size& outChunkPos);
   
   ChunkEntry* getChunkForPosition(ChunkEntry* fromChunk,
-                                      data::v_io_size pos,
-                                      data::v_io_size& outChunkPos);
+                                  v_buff_size pos,
+                                  v_buff_size& outChunkPos);
   
 public:
 
@@ -165,7 +165,7 @@ public:
    * @param count - size of data in bytes.
    * @return - actual number of bytes written.
    */
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   /**
    * Set stream I/O mode.
@@ -186,7 +186,7 @@ public:
    * @param count - number of bytes to read.
    * @return - actual number of bytes read from ChunkedBuffer and written to buffer.
    */
-  data::v_io_size readSubstring(void *buffer, data::v_io_size pos, data::v_io_size count);
+  data::v_io_size readSubstring(void *buffer, v_buff_size pos, v_buff_size count);
 
   /**
    * Create &id:oatpp::String; from part of ChunkedBuffer.
@@ -194,7 +194,7 @@ public:
    * @param count - size of bytes to write to substring.
    * @return - &id:oatpp::String;
    */
-  oatpp::String getSubstring(data::v_io_size pos, data::v_io_size count);
+  oatpp::String getSubstring(v_buff_size pos, v_buff_size count);
 
   /**
    * Create &id:oatpp::String; from all data in ChunkedBuffer.
@@ -225,7 +225,7 @@ public:
    * Get number of bytes written to ChunkedBuffer.
    * @return - number of bytes written to ChunkedBuffer.
    */
-  data::v_io_size getSize();
+  v_buff_size getSize();
 
   /**
    * Clear data in ChunkedBuffer.

--- a/src/oatpp/core/data/stream/FileStream.cpp
+++ b/src/oatpp/core/data/stream/FileStream.cpp
@@ -54,7 +54,7 @@ std::FILE* FileInputStream::getFile() {
   return m_file;
 }
 
-data::v_io_size FileInputStream::read(void *data, data::v_io_size count) {
+data::v_io_size FileInputStream::read(void *data, v_buff_size count) {
   return std::fread(data, 1, count, m_file);
 }
 
@@ -110,7 +110,7 @@ std::FILE* FileOutputStream::getFile() {
   return m_file;
 }
 
-data::v_io_size FileOutputStream::write(const void *data, data::v_io_size count) {
+data::v_io_size FileOutputStream::write(const void *data, v_buff_size count) {
   return std::fwrite(data, 1, count, m_file);
 }
 

--- a/src/oatpp/core/data/stream/FileStream.hpp
+++ b/src/oatpp/core/data/stream/FileStream.hpp
@@ -72,7 +72,7 @@ public:
    * @param count - size of the buffer.
    * @return - actual number of bytes read.
    */
-  data::v_io_size read(void *data, data::v_io_size count) override;
+  data::v_io_size read(void *data, v_buff_size count) override;
 
   /**
    * Implementation of InputStream must suggest async actions for I/O results. <br>
@@ -139,7 +139,7 @@ public:
    * @param count - number of bytes to write.
    * @return - actual number of bytes written. &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   /**
    * Implementation of OutputStream must suggest async actions for I/O results. <br>

--- a/src/oatpp/core/data/stream/Stream.cpp
+++ b/src/oatpp/core/data/stream/Stream.cpp
@@ -98,17 +98,17 @@ AsyncInlineWriteData::AsyncInlineWriteData()
   , bytesLeft(0)
 {}
 
-AsyncInlineWriteData::AsyncInlineWriteData(const void* data, data::v_io_size size)
+AsyncInlineWriteData::AsyncInlineWriteData(const void* data, v_buff_size size)
   : currBufferPtr(data)
   , bytesLeft(size)
 {}
 
-void AsyncInlineWriteData::set(const void* data, data::v_io_size size) {
+void AsyncInlineWriteData::set(const void* data, v_buff_size size) {
   currBufferPtr = data;
   bytesLeft = size;
 }
 
-void AsyncInlineWriteData::inc(data::v_io_size amount) {
+void AsyncInlineWriteData::inc(v_buff_size amount) {
   currBufferPtr = &((p_char8) currBufferPtr)[amount];
   bytesLeft -= amount;
 }
@@ -126,17 +126,17 @@ AsyncInlineReadData::AsyncInlineReadData()
   , bytesLeft(0)
 {}
 
-AsyncInlineReadData::AsyncInlineReadData(void* data, data::v_io_size size)
+AsyncInlineReadData::AsyncInlineReadData(void* data, v_buff_size size)
   : currBufferPtr(data)
   , bytesLeft(size)
 {}
 
-void AsyncInlineReadData::set(void* data, data::v_io_size size) {
+void AsyncInlineReadData::set(void* data, v_buff_size size) {
   currBufferPtr = data;
   bytesLeft = size;
 }
 
-void AsyncInlineReadData::inc(data::v_io_size amount) {
+void AsyncInlineReadData::inc(v_buff_size amount) {
   currBufferPtr = &((p_char8) currBufferPtr)[amount];
   bytesLeft -= amount;
 }
@@ -162,7 +162,7 @@ DefaultWriteCallback::DefaultWriteCallback(OutputStream* stream)
   : m_stream(stream)
 {}
 
-data::v_io_size DefaultWriteCallback::write(const void *data, data::v_io_size count) {
+data::v_io_size DefaultWriteCallback::write(const void *data, v_buff_size count) {
   return writeExactSizeData(m_stream, data, count);
 }
 
@@ -287,15 +287,15 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, bool value) {
   
 oatpp::data::v_io_size transfer(InputStream* fromStream,
                                 WriteCallback* writeCallback,
-                                oatpp::data::v_io_size transferSize,
+                                v_buff_size transferSize,
                                 void* buffer,
-                                oatpp::data::v_io_size bufferSize)
+                                v_buff_size bufferSize)
 {
-  
-  oatpp::data::v_io_size progress = 0;
+
+  v_buff_size progress = 0;
   
   while (transferSize == 0 || progress < transferSize) {
-    oatpp::data::v_io_size desiredReadCount = transferSize - progress;
+    v_buff_size desiredReadCount = transferSize - progress;
     if(transferSize == 0 || desiredReadCount > bufferSize){
       desiredReadCount = bufferSize;
     }
@@ -303,7 +303,7 @@ oatpp::data::v_io_size transfer(InputStream* fromStream,
     if(readResult > 0) {
 
       p_char8 data = (p_char8) buffer;
-      oatpp::data::v_io_size bytesLeft = readResult;
+      v_buff_size bytesLeft = readResult;
       while(bytesLeft > 0) {
         auto writeResult = writeCallback->write(data, bytesLeft);
         if(writeResult > 0) {
@@ -332,7 +332,7 @@ oatpp::data::v_io_size transfer(InputStream* fromStream,
 
 oatpp::async::CoroutineStarter transferAsync(const std::shared_ptr<InputStream>& fromStream,
                                              const std::shared_ptr<AsyncWriteCallback>& writeCallback,
-                                             oatpp::data::v_io_size transferSize,
+                                             v_buff_size transferSize,
                                              const std::shared_ptr<oatpp::data::buffer::IOBuffer>& buffer)
 {
   
@@ -340,11 +340,11 @@ oatpp::async::CoroutineStarter transferAsync(const std::shared_ptr<InputStream>&
   private:
     std::shared_ptr<InputStream> m_fromStream;
     std::shared_ptr<AsyncWriteCallback> m_writeCallback;
-    oatpp::data::v_io_size m_transferSize;
-    oatpp::data::v_io_size m_progress;
+    v_buff_size m_transferSize;
+    v_buff_size m_progress;
     std::shared_ptr<oatpp::data::buffer::IOBuffer> m_buffer;
-    
-    oatpp::data::v_io_size m_desiredReadCount;
+
+    v_buff_size m_desiredReadCount;
 
     AsyncInlineReadData m_inlineReadData;
     AsyncInlineWriteData m_inlineWriteData;
@@ -353,7 +353,7 @@ oatpp::async::CoroutineStarter transferAsync(const std::shared_ptr<InputStream>&
     
     TransferCoroutine(const std::shared_ptr<InputStream>& fromStream,
                       const std::shared_ptr<AsyncWriteCallback>& writeCallback,
-                      oatpp::data::v_io_size transferSize,
+                      v_buff_size transferSize,
                       const std::shared_ptr<oatpp::data::buffer::IOBuffer>& buffer)
       : m_fromStream(fromStream)
       , m_writeCallback(writeCallback)
@@ -466,7 +466,7 @@ oatpp::async::Action writeExactSizeDataAsyncInline(oatpp::data::stream::OutputSt
 }
 
 oatpp::async::CoroutineStarter writeExactSizeDataAsync(const std::shared_ptr<oatpp::data::stream::OutputStream>& stream,
-                                                       const void* data, data::v_io_size size)
+                                                       const void* data, v_buff_size size)
 {
 
   class WriteDataCoroutine : public oatpp::async::Coroutine<WriteDataCoroutine> {
@@ -476,7 +476,7 @@ oatpp::async::CoroutineStarter writeExactSizeDataAsync(const std::shared_ptr<oat
   public:
 
     WriteDataCoroutine(const std::shared_ptr<oatpp::data::stream::OutputStream>& stream,
-                       const void* data, data::v_io_size size)
+                       const void* data, v_buff_size size)
       : m_stream(stream)
       , m_inlineData(data, size)
     {}
@@ -527,10 +527,10 @@ oatpp::async::Action readExactSizeDataAsyncInline(oatpp::data::stream::InputStre
   return std::forward<oatpp::async::Action>(nextAction);
 }
   
-oatpp::data::v_io_size readExactSizeData(oatpp::data::stream::InputStream* stream, void* data, data::v_io_size size) {
+oatpp::data::v_io_size readExactSizeData(oatpp::data::stream::InputStream* stream, void* data, v_buff_size size) {
   
   char* buffer = (char*) data;
-  oatpp::data::v_io_size progress = 0;
+  v_buff_size progress = 0;
   
   while (progress < size) {
     
@@ -551,10 +551,10 @@ oatpp::data::v_io_size readExactSizeData(oatpp::data::stream::InputStream* strea
   
 }
   
-oatpp::data::v_io_size writeExactSizeData(oatpp::data::stream::OutputStream* stream, const void* data, data::v_io_size size) {
+oatpp::data::v_io_size writeExactSizeData(oatpp::data::stream::OutputStream* stream, const void* data, v_buff_size size) {
   
   const char* buffer = (char*)data;
-  oatpp::data::v_io_size progress = 0;
+  v_buff_size progress = 0;
   
   while (progress < size) {
 

--- a/src/oatpp/core/data/stream/Stream.hpp
+++ b/src/oatpp/core/data/stream/Stream.hpp
@@ -66,7 +66,7 @@ public:
    * @param count - number of bytes to write.
    * @return - actual number of bytes written. &id:oatpp::data::v_io_size;.
    */
-  virtual data::v_io_size write(const void *data, data::v_io_size count) = 0;
+  virtual data::v_io_size write(const void *data, v_buff_size count) = 0;
 
   /**
    * Implementation of OutputStream must suggest async actions for I/O results. <br>
@@ -136,7 +136,7 @@ public:
    * @param count - size of the buffer.
    * @return - actual number of bytes read.
    */
-  virtual data::v_io_size read(void *data, data::v_io_size count) = 0;
+  virtual data::v_io_size read(void *data, v_buff_size count) = 0;
 
   /**
    * Implementation of InputStream must suggest async actions for I/O results. <br>
@@ -189,11 +189,11 @@ public:
     return Shared_CompoundIOStream_Pool::allocateShared(outputStream, inputStream);
   }
   
-  data::v_io_size write(const void *data, data::v_io_size count) override {
+  data::v_io_size write(const void *data, v_buff_size count) override {
     return m_outputStream->write(data, count);
   }
   
-  data::v_io_size read(void *data, data::v_io_size count) override {
+  data::v_io_size read(void *data, v_buff_size count) override {
     return m_inputStream->read(data, count);
   }
 
@@ -303,7 +303,7 @@ struct AsyncInlineWriteData {
   /**
    * Bytes left to write from the buffer.
    */
-  data::v_io_size bytesLeft;
+  v_buff_size bytesLeft;
 
   /**
    * Default constructor.
@@ -315,21 +315,21 @@ struct AsyncInlineWriteData {
    * @param data
    * @param size
    */
-  AsyncInlineWriteData(const void* data, data::v_io_size size);
+  AsyncInlineWriteData(const void* data, v_buff_size size);
 
   /**
    * Set `currBufferPtr` and `bytesLeft` values. <br>
    * @param data - pointer to buffer containing data to be written.
    * @param size - size in bytes of the buffer.
    */
-  void set(const void* data, data::v_io_size size);
+  void set(const void* data, v_buff_size size);
 
   /**
    * Increase position in the write buffer by `amount` bytes. <br>
    * This will increase `currBufferPtr` and descrease `bytesLeft` values.
    * @param amount
    */
-  void inc(data::v_io_size amount);
+  void inc(v_buff_size amount);
 
   /**
    * Same as `inc(bytesLeft).`
@@ -351,7 +351,7 @@ struct AsyncInlineReadData {
   /**
    * Bytes left to read to the buffer.
    */
-  data::v_io_size bytesLeft;
+  v_buff_size bytesLeft;
 
   /**
    * Default constructor.
@@ -363,21 +363,21 @@ struct AsyncInlineReadData {
    * @param data
    * @param size
    */
-  AsyncInlineReadData(void* data, data::v_io_size size);
+  AsyncInlineReadData(void* data, v_buff_size size);
 
   /**
    * Set `currBufferPtr` and `bytesLeft` values. <br>
    * @param data - pointer to buffer to store read data.
    * @param size - size in bytes of the buffer.
    */
-  void set(void* data, data::v_io_size size);
+  void set(void* data, v_buff_size size);
 
   /**
    * Increase position in the read buffer by `amount` bytes. <br>
    * This will increase `currBufferPtr` and descrease `bytesLeft` values.
    * @param amount
    */
-  void inc(data::v_io_size amount);
+  void inc(v_buff_size amount);
 
   /**
    * Same as `inc(bytesLeft).`
@@ -403,7 +403,7 @@ public:
    * @param count - size of the data in bytes.
    * @return - &id:oatpp::data::v_io_size;.
    */
-  virtual data::v_io_size write(const void *data, data::v_io_size count) = 0;
+  virtual data::v_io_size write(const void *data, v_buff_size count) = 0;
 };
 
 /**
@@ -451,7 +451,7 @@ public:
    * @param count - data size.
    * @return - data processing Coroutine-Starter. &id:oatpp::async::CoroutineStarter;.
    */
-  virtual async::CoroutineStarter writeAsync(const void *data, data::v_io_size count) = 0;
+  virtual async::CoroutineStarter writeAsync(const void *data, v_buff_size count) = 0;
 
 };
 
@@ -476,7 +476,7 @@ public:
    * @param count - size of the data in bytes.
    * @return - &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 };
 
 /**
@@ -522,7 +522,7 @@ public:
    * @param count - size of the buffer.
    * @return - actual number of bytes written to buffer. 0 - to indicate end-of-file.
    */
-  virtual data::v_io_size read(void *buffer, data::v_io_size count) = 0;
+  virtual data::v_io_size read(void *buffer, v_buff_size count) = 0;
 
 };
 
@@ -570,9 +570,9 @@ public:
  */
 oatpp::data::v_io_size transfer(InputStream* fromStream,
                                 WriteCallback* writeCallback,
-                                oatpp::data::v_io_size transferSize,
+                                v_buff_size transferSize,
                                 void* buffer,
-                                oatpp::data::v_io_size bufferSize);
+                                v_buff_size bufferSize);
   
   
 /**
@@ -580,7 +580,7 @@ oatpp::data::v_io_size transfer(InputStream* fromStream,
  */
 oatpp::async::CoroutineStarter transferAsync(const std::shared_ptr<InputStream>& fromStream,
                                              const std::shared_ptr<AsyncWriteCallback>& writeCallback,
-                                             oatpp::data::v_io_size transferSize,
+                                             v_buff_size transferSize,
                                              const std::shared_ptr<oatpp::data::buffer::IOBuffer>& buffer);
 
   
@@ -589,7 +589,7 @@ oatpp::async::Action writeExactSizeDataAsyncInline(oatpp::data::stream::OutputSt
                                                    oatpp::async::Action&& nextAction);
 
 oatpp::async::CoroutineStarter writeExactSizeDataAsync(const std::shared_ptr<oatpp::data::stream::OutputStream>& stream,
-                                                       const void* data, data::v_io_size size);
+                                                       const void* data, v_buff_size size);
 
 oatpp::async::Action readSomeDataAsyncInline(oatpp::data::stream::InputStream* stream,
                                              AsyncInlineReadData& inlineData,
@@ -605,14 +605,14 @@ oatpp::async::Action readExactSizeDataAsyncInline(oatpp::data::stream::InputStre
  * returns exact amount of bytes was read.
  * return result can be < size only in case of some disaster like connection reset by peer
  */
-oatpp::data::v_io_size readExactSizeData(oatpp::data::stream::InputStream* stream, void* data, data::v_io_size size);
+oatpp::data::v_io_size readExactSizeData(oatpp::data::stream::InputStream* stream, void* data, v_buff_size size);
   
 /**
  * Write exact amount of bytes to stream.
  * returns exact amount of bytes was written.
  * return result can be < size only in case of some disaster like broken pipe
  */
-oatpp::data::v_io_size writeExactSizeData(oatpp::data::stream::OutputStream* stream, const void* data, data::v_io_size size);
+oatpp::data::v_io_size writeExactSizeData(oatpp::data::stream::OutputStream* stream, const void* data, v_buff_size size);
   
 }}}
 

--- a/src/oatpp/core/data/stream/StreamBufferedProxy.cpp
+++ b/src/oatpp/core/data/stream/StreamBufferedProxy.cpp
@@ -26,7 +26,7 @@
 
 namespace oatpp { namespace data{ namespace stream {
   
-data::v_io_size OutputStreamBufferedProxy::write(const void *data, data::v_io_size count) {
+data::v_io_size OutputStreamBufferedProxy::write(const void *data, v_buff_size count) {
   if(m_buffer.availableToWrite() > 0) {
     return m_buffer.write(data, count);
   } else {
@@ -61,7 +61,7 @@ oatpp::async::CoroutineStarter OutputStreamBufferedProxy::flushAsync() {
   return m_buffer.flushToStreamAsync(m_outputStream);
 }
   
-data::v_io_size InputStreamBufferedProxy::read(void *data, data::v_io_size count) {
+data::v_io_size InputStreamBufferedProxy::read(void *data, v_buff_size count) {
   
   if(m_buffer.availableToRead() > 0) {
     return m_buffer.read(data, count);
@@ -75,7 +75,7 @@ data::v_io_size InputStreamBufferedProxy::read(void *data, data::v_io_size count
   
 }
 
-data::v_io_size InputStreamBufferedProxy::peek(void *data, data::v_io_size count) {
+data::v_io_size InputStreamBufferedProxy::peek(void *data, v_buff_size count) {
 
   if(m_buffer.availableToRead() > 0) {
     return m_buffer.peek(data, count);
@@ -89,7 +89,7 @@ data::v_io_size InputStreamBufferedProxy::peek(void *data, data::v_io_size count
 
 }
 
-data::v_io_size InputStreamBufferedProxy::commitReadOffset(data::v_io_size count) {
+data::v_io_size InputStreamBufferedProxy::commitReadOffset(v_buff_size count) {
   return m_buffer.commitReadOffset(count);
 }
 

--- a/src/oatpp/core/data/stream/StreamBufferedProxy.hpp
+++ b/src/oatpp/core/data/stream/StreamBufferedProxy.hpp
@@ -55,7 +55,7 @@ public:
     return Shared_OutputStreamBufferedProxy_Pool::allocateShared(outputStream, memoryLabel);
   }
   
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   oatpp::async::Action suggestOutputStreamAction(data::v_io_size ioResult) override;
 
@@ -117,11 +117,11 @@ public:
     return Shared_InputStreamBufferedProxy_Pool::allocateShared(inputStream, memoryLabel, bufferReadPosition, bufferWritePosition, bufferCanRead);
   }
   
-  data::v_io_size read(void *data, data::v_io_size count) override;
+  data::v_io_size read(void *data, v_buff_size count) override;
 
-  data::v_io_size peek(void *data, data::v_io_size count);
+  data::v_io_size peek(void *data, v_buff_size count);
 
-  data::v_io_size commitReadOffset(data::v_io_size count);
+  data::v_io_size commitReadOffset(v_buff_size count);
 
   oatpp::async::Action suggestInputStreamAction(data::v_io_size ioResult) override;
 

--- a/src/oatpp/core/parser/Caret.cpp
+++ b/src/oatpp/core/parser/Caret.cpp
@@ -59,7 +59,7 @@ namespace oatpp { namespace parser {
     return &m_caret->m_data[m_start];
   }
 
-  v_int64 Caret::Label::getSize(){
+  v_buff_size Caret::Label::getSize(){
     if(m_end == -1) {
       return m_caret->m_pos - m_start;
     }
@@ -67,7 +67,7 @@ namespace oatpp { namespace parser {
   }
 
   oatpp::String Caret::Label::toString(bool saveAsOwnData){
-    v_int64 end = m_end;
+    v_buff_size end = m_end;
     if(end == -1){
       end = m_caret->m_pos;
     }
@@ -79,7 +79,7 @@ namespace oatpp { namespace parser {
   }
 
   std::string Caret::Label::std_str(){
-    v_int64 end = m_end;
+    v_buff_size end = m_end;
     if(end == -1){
       end = m_caret->m_pos;
     }
@@ -106,7 +106,7 @@ Caret::StateSaveGuard::StateSaveGuard(Caret& caret)
   m_caret.m_errorCode = m_savedErrorCode;
 }
 
-v_int64 Caret::StateSaveGuard::getSavedPosition() {
+v_buff_size Caret::StateSaveGuard::getSavedPosition() {
   return m_savedPosition;
 }
 
@@ -125,7 +125,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     : Caret((p_char8)text, std::strlen(text))
   {}
   
-  Caret::Caret(p_char8 parseData, v_int64 dataSize)
+  Caret::Caret(p_char8 parseData, v_buff_size dataSize)
     : m_data(parseData)
     , m_size(dataSize)
     , m_pos(0)
@@ -143,7 +143,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return std::make_shared<Caret>(text);
   }
   
-  std::shared_ptr<Caret> Caret::createShared(p_char8 parseData, v_int64 dataSize){
+  std::shared_ptr<Caret> Caret::createShared(p_char8 parseData, v_buff_size dataSize){
     return std::make_shared<Caret>(parseData, dataSize);
   }
   
@@ -162,7 +162,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return &m_data[m_pos];
   }
   
-  v_int64 Caret::getDataSize(){
+  v_buff_size Caret::getDataSize(){
     return m_size;
   }
 
@@ -170,11 +170,11 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return m_dataMemoryHandle;
   }
 
-  void Caret::setPosition(v_int64 position){
+  void Caret::setPosition(v_buff_size position){
     m_pos = position;
   }
   
-  v_int64 Caret::getPosition(){
+  v_buff_size Caret::getPosition(){
     return m_pos;
   }
   
@@ -208,7 +208,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     m_pos ++;
   }
   
-  void Caret::inc(v_int64 amount){
+  void Caret::inc(v_buff_size amount){
     m_pos+= amount;
   }
   
@@ -248,7 +248,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return skipCharsFromSet((p_char8)set, std::strlen(set));
   }
   
-  bool Caret::skipCharsFromSet(p_char8 set, v_int64 setSize){
+  bool Caret::skipCharsFromSet(p_char8 set, v_buff_size setSize){
     
     while(m_pos < m_size){
       if(!isAtCharFromSet(set, setSize)){
@@ -261,17 +261,17 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     
   }
   
-  v_int64 Caret::findCharFromSet(const char* set){
+  v_buff_size Caret::findCharFromSet(const char* set){
     return findCharFromSet((p_char8) set, std::strlen(set));
   }
   
-  v_int64 Caret::findCharFromSet(p_char8 set, v_int64 setSize){
+  v_buff_size Caret::findCharFromSet(p_char8 set, v_buff_size setSize){
     
     while(m_pos < m_size){
       
       v_char8 a = m_data[m_pos];
       
-      for(v_int64 i = 0; i < setSize; i++){
+      for(v_buff_size i = 0; i < setSize; i++){
         if(set[i] == a)
           return a;
       }
@@ -354,7 +354,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_INTEGER;
     }
-    m_pos = ((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_buff_size) end - (v_buff_size) m_data);
     return result;
   }
 
@@ -365,7 +365,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_INTEGER;
     }
-    m_pos = ((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_buff_size) end - (v_buff_size) m_data);
     return result;
   }
   
@@ -376,7 +376,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_FLOAT;
     }
-    m_pos = ((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_buff_size) end - (v_buff_size) m_data);
     return result;
   }
   
@@ -387,7 +387,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_FLOAT;
     }
-    m_pos = ((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_buff_size) end - (v_buff_size) m_data);
     return result;
   }
   
@@ -395,11 +395,11 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return isAtText((p_char8)text, std::strlen(text), skipIfTrue);
   }
   
-  bool Caret::isAtText(p_char8 text, v_int64 textSize, bool skipIfTrue){
+  bool Caret::isAtText(p_char8 text, v_buff_size textSize, bool skipIfTrue){
     
     if(textSize <= m_size - m_pos){
       
-      for(v_int64 i = 0; i < textSize; i++){
+      for(v_buff_size i = 0; i < textSize; i++){
         
         if(text[i] != m_data[m_pos + i]){
           return false;
@@ -423,11 +423,11 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return isAtTextNCS((p_char8)text, std::strlen(text), skipIfTrue);
   }
   
-  bool Caret::isAtTextNCS(p_char8 text, v_int64 textSize, bool skipIfTrue){
+  bool Caret::isAtTextNCS(p_char8 text, v_buff_size textSize, bool skipIfTrue){
     
     if(textSize <= m_size - m_pos){
       
-      for(v_int64 i = 0; i < textSize; i++){
+      for(v_buff_size i = 0; i < textSize; i++){
         
         v_char8 c1 = text[i];
         v_char8 c2 = m_data[m_pos + i];
@@ -492,7 +492,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return findText((p_char8) text, std::strlen(text));
   }
   
-  bool Caret::findText(p_char8 text, v_int64 textSize) {
+  bool Caret::findText(p_char8 text, v_buff_size textSize) {
     m_pos = (std::search(&m_data[m_pos], &m_data[m_size], text, text + textSize) - m_data);
     return m_pos != m_size;
   }
@@ -501,11 +501,11 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return isAtCharFromSet((p_char8)set, std::strlen(set));
   }
   
-  bool Caret::isAtCharFromSet(p_char8 set, v_int64 setSize) const{
+  bool Caret::isAtCharFromSet(p_char8 set, v_buff_size setSize) const{
     
     v_char8 a = m_data[m_pos];
     
-    for(v_int64 i = 0; i < setSize; i++){
+    for(v_buff_size i = 0; i < setSize; i++){
       if(a == set[i]){
         return true;
       }
@@ -533,7 +533,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     return m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c;
   }
   
-  bool Caret::canContinueAtChar(v_char8 c, v_int64 skipChars){
+  bool Caret::canContinueAtChar(v_char8 c, v_buff_size skipChars){
     
     if(m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c){
       m_pos = m_pos + skipChars;

--- a/src/oatpp/core/parser/Caret.hpp
+++ b/src/oatpp/core/parser/Caret.hpp
@@ -49,8 +49,8 @@ public:
   class Label {
   private:
     Caret* m_caret;
-    v_int64 m_start;
-    v_int64 m_end;
+    v_buff_size m_start;
+    v_buff_size m_end;
   public:
 
     /**
@@ -79,7 +79,7 @@ public:
      * Get size of labeled data.
      * @return
      */
-    v_int64 getSize();
+    v_buff_size getSize();
 
     /**
      * Create &id:oatpp::String; from labeled data.
@@ -110,7 +110,7 @@ public:
   class StateSaveGuard {
   private:
     Caret& m_caret;
-    v_int64 m_savedPosition;
+    v_buff_size m_savedPosition;
     const char* m_savedErrorMessage;
     v_int64 m_savedErrorCode;
   public:
@@ -130,7 +130,7 @@ public:
      * Get caret saved position.
      * @return
      */
-    v_int64 getSavedPosition();
+    v_buff_size getSavedPosition();
 
     /**
      * Get caret saved error message.
@@ -148,19 +148,19 @@ public:
 
 private:
   p_char8 m_data;
-  v_int64 m_size;
-  v_int64 m_pos;
+  v_buff_size m_size;
+  v_buff_size m_pos;
   const char* m_errorMessage;
   v_int64 m_errorCode;
   std::shared_ptr<oatpp::base::StrBuffer> m_dataMemoryHandle;
 public:
   Caret(const char* text);
-  Caret(p_char8 parseData, v_int64 dataSize);
+  Caret(p_char8 parseData, v_buff_size dataSize);
   Caret(const oatpp::String& str);
 public:
   
   static std::shared_ptr<Caret> createShared(const char* text);
-  static std::shared_ptr<Caret> createShared(p_char8 parseData, v_int64 dataSize);
+  static std::shared_ptr<Caret> createShared(p_char8 parseData, v_buff_size dataSize);
   static std::shared_ptr<Caret> createShared(const oatpp::String& str);
 
   virtual ~Caret();
@@ -181,7 +181,7 @@ public:
    * Get size of a data
    * @return
    */
-  v_int64 getDataSize();
+  v_buff_size getDataSize();
 
   /**
    * Get data memoryHandle.
@@ -193,13 +193,13 @@ public:
    * Set caret position relative to data
    * @param position
    */
-  void setPosition(v_int64 position);
+  void setPosition(v_buff_size position);
 
   /**
    * Get caret position relative to data
    * @return
    */
-  v_int64 getPosition();
+  v_buff_size getPosition();
 
   /**
    * Set error message and error code.
@@ -247,7 +247,7 @@ public:
    * Increase caret position by amount
    * @param amount
    */
-  void inc(v_int64 amount);
+  void inc(v_buff_size amount);
 
   /**
    * Skip chars: [' ', '\t', '\n', '\r','\f']
@@ -285,14 +285,14 @@ public:
    * @param setSize
    * @return true if other char found
    */
-  bool skipCharsFromSet(p_char8 set, v_int64 setSize);
+  bool skipCharsFromSet(p_char8 set, v_buff_size setSize);
 
   /**
    * Find one of chars defined by set.
    * @param set
    * @return char found or -1 if no char found
    */
-  v_int64 findCharFromSet(const char* set);
+  v_buff_size findCharFromSet(const char* set);
 
   /**
    * Find one of chars defined by set.
@@ -300,7 +300,7 @@ public:
    * @param setSize
    * @return char found or -1 if no char found
    */
-  v_int64 findCharFromSet(p_char8 set, v_int64 setSize);
+  v_buff_size findCharFromSet(p_char8 set, v_buff_size setSize);
 
   /**
    * Find "\r\n" chars
@@ -396,7 +396,7 @@ public:
    * @param skipIfTrue - increase position if true
    * @return
    */
-  bool isAtText(p_char8 text, v_int64 textSize, bool skipIfTrue = false);
+  bool isAtText(p_char8 text, v_buff_size textSize, bool skipIfTrue = false);
 
   /**
    * Check if follows text (Not Case Sensitive)
@@ -413,7 +413,7 @@ public:
    * @param skipIfTrue - increase position if true
    * @return
    */
-  bool isAtTextNCS(p_char8 text, v_int64 textSize, bool skipIfTrue = false);
+  bool isAtTextNCS(p_char8 text, v_buff_size textSize, bool skipIfTrue = false);
 
   /**
    * Parse enclosed string.
@@ -439,7 +439,7 @@ public:
    * @param textSize
    * @return true if found
    */
-  bool findText(p_char8 text, v_int64 textSize);
+  bool findText(p_char8 text, v_buff_size textSize);
 
   /**
    * Check if caret is at char defined by set
@@ -456,7 +456,7 @@ public:
    * @param setSize
    * @return
    */
-  bool isAtCharFromSet(p_char8 set, v_int64 setSize) const;
+  bool isAtCharFromSet(p_char8 set, v_buff_size setSize) const;
 
   /**
    * Check if caret is at char
@@ -491,7 +491,7 @@ public:
    * @param skipChars
    * @return
    */
-  bool canContinueAtChar(v_char8 c, v_int64 skipChars);
+  bool canContinueAtChar(v_char8 c, v_buff_size skipChars);
 
   /**
    * Check if caret position < dataSize and not error is set

--- a/src/oatpp/core/parser/ParsingError.cpp
+++ b/src/oatpp/core/parser/ParsingError.cpp
@@ -26,7 +26,7 @@
 
 namespace oatpp { namespace parser {
 
-ParsingError::ParsingError(const oatpp::String &message, v_int64 code, v_int64 position)
+ParsingError::ParsingError(const oatpp::String &message, v_int64 code, v_buff_size position)
   :std::runtime_error(message->std_str())
   , m_message(message)
   , m_code(code)
@@ -41,7 +41,7 @@ v_int64 ParsingError::getCode() const {
   return m_code;
 }
 
-v_int64 ParsingError::getPosition() const {
+v_buff_size ParsingError::getPosition() const {
   return m_position;
 }
 

--- a/src/oatpp/core/parser/ParsingError.hpp
+++ b/src/oatpp/core/parser/ParsingError.hpp
@@ -38,7 +38,7 @@ class ParsingError : public std::runtime_error {
 private:
   oatpp::String m_message;
   v_int64 m_code;
-  v_int64 m_position;
+  v_buff_size m_position;
 public:
 
   /**
@@ -46,7 +46,7 @@ public:
    * @param message
    * @param position
    */
-  ParsingError(const oatpp::String &message, v_int64 code, v_int64 position);
+  ParsingError(const oatpp::String &message, v_int64 code, v_buff_size position);
 
   /**
    * get error message
@@ -64,7 +64,7 @@ public:
    * get parsing position of the error
    * @return
    */
-  v_int64 getPosition() const;
+  v_buff_size getPosition() const;
 
 };
 

--- a/src/oatpp/encoding/Base64.cpp
+++ b/src/oatpp/encoding/Base64.cpp
@@ -53,16 +53,16 @@ v_char8 Base64::getAlphabetCharIndex(v_char8 a, const char* auxiliaryChars) {
   return 255;
 }
   
-v_int64 Base64::calcEncodedStringSize(v_int64 size) {
-  v_int64 size3 = size / 3;
-  v_int64 rSize = size3 * 3;
+v_buff_size Base64::calcEncodedStringSize(v_buff_size size) {
+  v_buff_size size3 = size / 3;
+  v_buff_size rSize = size3 * 3;
   if(rSize < size){
     rSize += 4;
   }
   return rSize + size3; // resultSize = (size3 * 3 + size3) = size3 * 4
 }
   
-v_int64 Base64::calcDecodedStringSize(const char* data, v_int64 size, v_int64& base64StrLength, const char* auxiliaryChars) {
+v_buff_size Base64::calcDecodedStringSize(const char* data, v_buff_size size, v_buff_size& base64StrLength, const char* auxiliaryChars) {
   
   base64StrLength = size;
   
@@ -70,7 +70,7 @@ v_int64 Base64::calcDecodedStringSize(const char* data, v_int64 size, v_int64& b
   v_char8 auxChar2 = auxiliaryChars[1];
   v_char8 paddingChar = auxiliaryChars[2];
   
-  v_int64 i = 0;
+  v_buff_size i = 0;
   while (i < size) {
     
     v_char8 a = data[i];
@@ -88,9 +88,9 @@ v_int64 Base64::calcDecodedStringSize(const char* data, v_int64 size, v_int64& b
     
   }
   
-  v_int64 size4 = i >> 2;
-  v_int64 size4d = i - (size4 << 2);
-  v_int64 resultSize = size4 * 3;
+  v_buff_size size4 = i >> 2;
+  v_buff_size size4d = i - (size4 << 2);
+  v_buff_size resultSize = size4 * 3;
   if(size4d > 0) {
     resultSize += size4d - 1;
   }
@@ -98,12 +98,12 @@ v_int64 Base64::calcDecodedStringSize(const char* data, v_int64 size, v_int64& b
   
 }
   
-bool Base64::isBase64String(const char* data, v_int64 size, const char* auxiliaryChars) {
-  v_int64 base64StrLength;
+bool Base64::isBase64String(const char* data, v_buff_size size, const char* auxiliaryChars) {
+  v_buff_size base64StrLength;
   return (calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars) >= 0);
 }
   
-oatpp::String Base64::encode(const void* data, v_int64 size, const char* alphabet) {
+oatpp::String Base64::encode(const void* data, v_buff_size size, const char* alphabet) {
   
   auto resultSize = calcEncodedStringSize(size);
   
@@ -112,7 +112,7 @@ oatpp::String Base64::encode(const void* data, v_int64 size, const char* alphabe
   p_char8 bdata = (p_char8) data;
   p_char8 resultData = result->getData();
   
-  v_int64 pos = 0;
+  v_buff_size pos = 0;
   while (pos + 2 < size) {
     
     v_char8 b0 = bdata[pos];
@@ -150,9 +150,9 @@ oatpp::String Base64::encode(const oatpp::String& data, const char* alphabet) {
   return encode(data->getData(), data->getSize(), alphabet);
 }
   
-oatpp::String Base64::decode(const char* data, v_int64 size, const char* auxiliaryChars) {
+oatpp::String Base64::decode(const char* data, v_buff_size size, const char* auxiliaryChars) {
   
-  v_int64 base64StrLength;
+  v_buff_size base64StrLength;
   auto resultSize = calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars);
   if(resultSize < 0) {
     throw DecodingError("Data is no base64 string. Make sure that auxiliaryChars match with encoder alphabet");
@@ -160,7 +160,7 @@ oatpp::String Base64::decode(const char* data, v_int64 size, const char* auxilia
   
   auto result = oatpp::String(resultSize);
   p_char8 resultData = result->getData();
-  v_int64 pos = 0;
+  v_buff_size pos = 0;
   while (pos + 3 < base64StrLength) {
     v_char8 b0 = getAlphabetCharIndex(data[pos], auxiliaryChars);
     v_char8 b1 = getAlphabetCharIndex(data[pos + 1], auxiliaryChars);
@@ -175,7 +175,7 @@ oatpp::String Base64::decode(const char* data, v_int64 size, const char* auxilia
     pos += 4;
   }
   
-  v_int64 posDiff = base64StrLength - pos;
+  v_buff_size posDiff = base64StrLength - pos;
   if(posDiff == 3) {
     v_char8 b0 = getAlphabetCharIndex(data[pos], auxiliaryChars);
     v_char8 b1 = getAlphabetCharIndex(data[pos + 1], auxiliaryChars);

--- a/src/oatpp/encoding/Base64.hpp
+++ b/src/oatpp/encoding/Base64.hpp
@@ -97,7 +97,7 @@ public:
    * @param size - size of string to encode.
    * @return - size of encoding result of a string of the given size
    */
-  static v_int64 calcEncodedStringSize(v_int64 size);
+  static v_buff_size calcEncodedStringSize(v_buff_size size);
 
   /**
    * Calculate size of decoding result. this method assumes that data passed as a param consists of standard base64 set of chars
@@ -108,7 +108,7 @@ public:
    * @param auxiliaryChars - configurable auxiliary chars.
    * @return - size of decoded data. If data passed is not a base64 string then -1 is returned.
    */
-  static v_int64 calcDecodedStringSize(const char* data, v_int64 size, v_int64& base64StrLength, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static v_buff_size calcDecodedStringSize(const char* data, v_buff_size size, v_buff_size& base64StrLength, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
 
   /**
    * Check if data is a valid base64 encoded string.
@@ -117,7 +117,7 @@ public:
    * @param auxiliaryChars - configurable auxiliary chars.
    * @return `(calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars) >= 0)`.
    */
-  static bool isBase64String(const char* data, v_int64 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static bool isBase64String(const char* data, v_buff_size size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
 
   /**
    * Encode data as base64 string.
@@ -126,7 +126,7 @@ public:
    * @param alphabet - base64 alphabet to use.
    * @return - encoded base64 string as &id:oatpp::String;.
    */
-  static oatpp::String encode(const void* data, v_int64 size, const char* alphabet = ALPHABET_BASE64);
+  static oatpp::String encode(const void* data, v_buff_size size, const char* alphabet = ALPHABET_BASE64);
 
   /**
    * Encode data as base64 string.
@@ -145,7 +145,7 @@ public:
    * @return - decoded data as &id:oatpp::String;.
    * @throws - &l:Base64::DecodingError;
    */
-  static oatpp::String decode(const char* data, v_int64 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static oatpp::String decode(const char* data, v_buff_size size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
   
   /**
    * Decode base64 encoded data. This method assumes that data passed as a param consists of standard base64 set of chars

--- a/src/oatpp/encoding/Unicode.cpp
+++ b/src/oatpp/encoding/Unicode.cpp
@@ -34,7 +34,7 @@
 
 namespace oatpp { namespace encoding {
   
-v_int64 Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
+v_buff_size Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
   
   if(firstByte < 128){
     return 1;
@@ -60,7 +60,7 @@ v_int64 Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
   
 }
   
-v_int64 Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
+v_buff_size Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
   if(code < 128) {
     return 1;
   } else if(code < 0x00000800){
@@ -77,7 +77,7 @@ v_int64 Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
   return 1;
 }
   
-v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int64& length){
+v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_buff_size& length){
   v_char8 byte = sequence[0];
   if(byte > 127){
     v_int32 code;
@@ -107,7 +107,7 @@ v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int64& length){
     }
     
     v_char8 bitIndex = 0;
-    for(v_int64 i = length; i > 1; i--){
+    for(v_buff_size i = length; i > 1; i--){
       code |= (sequence[i - 1] & 63) << bitIndex;
       bitIndex += 6;
     }
@@ -118,7 +118,7 @@ v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int64& length){
   }
 }
   
-v_int64 Unicode::decodeUtf8Char(v_int32 code, p_char8 buffer) {
+v_buff_size Unicode::decodeUtf8Char(v_int32 code, p_char8 buffer) {
   if(code >= 0x00000080 && code < 0x00000800){
     *((p_int16) buffer) = htons(((((code >> 6) & 31) | 192) << 8) | ((code & 63) | 128));
     return 2;

--- a/src/oatpp/encoding/Unicode.hpp
+++ b/src/oatpp/encoding/Unicode.hpp
@@ -39,14 +39,14 @@ public:
    * @param firstByte - first byte of UTF-8 character.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int64 getUtf8CharSequenceLength(v_char8 firstByte);
+  static v_buff_size getUtf8CharSequenceLength(v_char8 firstByte);
 
   /**
    * Get length in bytes of UTF-8 character by its code.
    * @param code - code of UTF-8 character.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int64 getUtf8CharSequenceLengthForCode(v_word32 code);
+  static v_buff_size getUtf8CharSequenceLengthForCode(v_word32 code);
 
   /**
    * Get code of UTF-8 character.
@@ -54,7 +54,7 @@ public:
    * @param length - out parameter. Length in bytes of UTF-8 character.
    * @return - code of UTF-8 character.
    */
-  static v_int32 encodeUtf8Char(p_char8 sequence, v_int64& length);
+  static v_int32 encodeUtf8Char(p_char8 sequence, v_buff_size& length);
 
   /**
    * Write UTF-8 character to buffer.
@@ -62,7 +62,7 @@ public:
    * @param buffer - pointer to write UTF-8 character to.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int64 decodeUtf8Char(v_int32 code, p_char8 buffer);
+  static v_buff_size decodeUtf8Char(v_int32 code, p_char8 buffer);
 
   /**
    * Get corresponding UTF-16 surrogate pair for symbol code.

--- a/src/oatpp/network/Connection.cpp
+++ b/src/oatpp/network/Connection.cpp
@@ -51,7 +51,7 @@ Connection::~Connection(){
   close();
 }
 
-data::v_io_size Connection::write(const void *buff, data::v_io_size count){
+data::v_io_size Connection::write(const void *buff, v_buff_size count){
 
 #if defined(WIN32) || defined(_WIN32)
 
@@ -102,7 +102,7 @@ data::v_io_size Connection::write(const void *buff, data::v_io_size count){
 
 }
 
-data::v_io_size Connection::read(void *buff, data::v_io_size count){
+data::v_io_size Connection::read(void *buff, v_buff_size count){
 
 #if defined(WIN32) || defined(_WIN32)
 

--- a/src/oatpp/network/Connection.hpp
+++ b/src/oatpp/network/Connection.hpp
@@ -74,7 +74,7 @@ public:
    * @param count - bytes count you want to write.
    * @return - actual amount of bytes written. See &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size write(const void *buff, data::v_io_size count) override;
+  data::v_io_size write(const void *buff, v_buff_size count) override;
 
   /**
    * Implementation of &id:oatpp::data::stream::IOStream::read;.
@@ -82,7 +82,7 @@ public:
    * @param count - buffer size.
    * @return - actual amount of bytes read. See &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size read(void *buff, data::v_io_size count) override;
+  data::v_io_size read(void *buff, v_buff_size count) override;
 
   /**
    * Implementation of OutputStream must suggest async actions for I/O results.

--- a/src/oatpp/network/ConnectionPool.cpp
+++ b/src/oatpp/network/ConnectionPool.cpp
@@ -64,11 +64,11 @@ ConnectionPool::ConnectionWrapper::~ConnectionWrapper() {
   }
 }
 
-data::v_io_size ConnectionPool::ConnectionWrapper::write(const void *buff, data::v_io_size count) {
+data::v_io_size ConnectionPool::ConnectionWrapper::write(const void *buff, v_buff_size count) {
   return m_connection->write(buff, count);
 }
 
-data::v_io_size ConnectionPool::ConnectionWrapper::read(void *buff, data::v_io_size count) {
+data::v_io_size ConnectionPool::ConnectionWrapper::read(void *buff, v_buff_size count) {
   return m_connection->read(buff, count);
 }
 

--- a/src/oatpp/network/ConnectionPool.cpp
+++ b/src/oatpp/network/ConnectionPool.cpp
@@ -110,7 +110,7 @@ bool ConnectionPool::ConnectionWrapper::isValid() {
 ConnectionPool::ConnectionPool(const std::shared_ptr<ConnectionProvider>& connectionProvider,
                v_int64 maxConnections,
                const std::chrono::duration<v_int64, std::micro>& maxConnectionTTL)
-  : m_pool(std::make_shared<Pool>(maxConnections, std::chrono::duration_cast<std::chrono::microseconds>(maxConnectionTTL).count()))
+  : m_pool(std::make_shared<Pool>(maxConnections, maxConnectionTTL.count()))
   , m_connectionProvider(connectionProvider)
 {
 

--- a/src/oatpp/network/ConnectionPool.hpp
+++ b/src/oatpp/network/ConnectionPool.hpp
@@ -89,8 +89,8 @@ public:
     ConnectionWrapper(const std::shared_ptr<IOStream>& connection, const std::shared_ptr<Pool>& pool);
     ~ConnectionWrapper();
 
-    data::v_io_size write(const void *buff, data::v_io_size count) override;
-    data::v_io_size read(void *buff, data::v_io_size count) override;
+    data::v_io_size write(const void *buff, v_buff_size count) override;
+    data::v_io_size read(void *buff, v_buff_size count) override;
 
     oatpp::async::Action suggestOutputStreamAction(data::v_io_size ioResult) override;
     oatpp::async::Action suggestInputStreamAction(data::v_io_size ioResult) override;

--- a/src/oatpp/network/Url.cpp
+++ b/src/oatpp/network/Url.cpp
@@ -29,9 +29,9 @@
 namespace oatpp { namespace network {
 
 oatpp::String Url::Parser::parseScheme(oatpp::parser::Caret& caret) {
-  v_int64 pos0 = caret.getPosition();
+  v_buff_size pos0 = caret.getPosition();
   caret.findChar(':');
-  v_int64 size = caret.getPosition() - pos0;
+  v_buff_size size = caret.getPosition() - pos0;
   if(size > 0) {
     std::unique_ptr<v_char8> buff(new v_char8[size]);
     std::memcpy(buff.get(), &caret.getData()[pos0], size);
@@ -44,12 +44,12 @@ oatpp::String Url::Parser::parseScheme(oatpp::parser::Caret& caret) {
 Url::Authority Url::Parser::parseAuthority(oatpp::parser::Caret& caret) {
   
   p_char8 data = caret.getData();
-  v_int64 pos0 = caret.getPosition();
-  v_int64 pos = pos0;
+  v_buff_size pos0 = caret.getPosition();
+  v_buff_size pos = pos0;
   
-  v_int64 hostPos = pos0;
-  v_int64 atPos = -1;
-  v_int64 portPos = -1;
+  v_buff_size hostPos = pos0;
+  v_buff_size atPos = -1;
+  v_buff_size portPos = -1;
   
   while (pos < caret.getDataSize()) {
     v_char8 a = data[pos];
@@ -82,7 +82,7 @@ Url::Authority Url::Parser::parseAuthority(oatpp::parser::Caret& caret) {
     result.host = oatpp::String((const char*)&data[hostPos], portPos - 1 - hostPos, true);
     char* end;
     result.port = std::strtol((const char*)&data[portPos], &end, 10);
-    bool success = (((v_int64)end - (v_int64)&data[portPos]) == pos - portPos);
+    bool success = (((v_buff_size)end - (v_buff_size)&data[portPos]) == pos - portPos);
     if(!success) {
       caret.setError("Invalid port string");
     }
@@ -110,7 +110,7 @@ void Url::Parser::parseQueryParams(Url::Parameters& params, oatpp::parser::Caret
     do {
       caret.inc();
       auto nameLabel = caret.putLabel();
-      v_int64 charFound = caret.findCharFromSet("=&");
+      v_buff_size charFound = caret.findCharFromSet("=&");
       if(charFound == '=') {
         nameLabel.end();
         caret.inc();

--- a/src/oatpp/network/virtual_/Pipe.cpp
+++ b/src/oatpp/network/virtual_/Pipe.cpp
@@ -38,7 +38,7 @@ void Pipe::Reader::setMaxAvailableToRead(data::v_io_size maxAvailableToRead) {
   m_maxAvailableToRead = maxAvailableToRead;
 }
   
-data::v_io_size Pipe::Reader::read(void *data, data::v_io_size count) {
+data::v_io_size Pipe::Reader::read(void *data, v_buff_size count) {
   
   if(m_maxAvailableToRead > -1 && count > m_maxAvailableToRead) {
     count = m_maxAvailableToRead;
@@ -121,7 +121,7 @@ void Pipe::Writer::setMaxAvailableToWrite(data::v_io_size maxAvailableToWrite) {
   m_maxAvailableToWrtie = maxAvailableToWrite;
 }
   
-data::v_io_size Pipe::Writer::write(const void *data, data::v_io_size count) {
+data::v_io_size Pipe::Writer::write(const void *data, v_buff_size count) {
   
   if(m_maxAvailableToWrtie > -1 && count > m_maxAvailableToWrtie) {
     count = m_maxAvailableToWrtie;

--- a/src/oatpp/network/virtual_/Pipe.hpp
+++ b/src/oatpp/network/virtual_/Pipe.hpp
@@ -109,7 +109,7 @@ public:
      * @param count - max count of bytes to read.
      * @return - &id:oatpp::data::v_io_size;.
      */
-    data::v_io_size read(void *data, data::v_io_size count) override;
+    data::v_io_size read(void *data, v_buff_size count) override;
 
     /**
      * Implementation of InputStream must suggest async actions for I/O results.
@@ -200,7 +200,7 @@ public:
      * @param count - data size.
      * @return - &id:oatpp::data::v_io_size;.
      */
-    data::v_io_size write(const void *data, data::v_io_size count) override;
+    data::v_io_size write(const void *data, v_buff_size count) override;
 
     /**
      * Implementation of OutputStream must suggest async actions for I/O results.

--- a/src/oatpp/network/virtual_/Socket.cpp
+++ b/src/oatpp/network/virtual_/Socket.cpp
@@ -44,11 +44,11 @@ void Socket::setMaxAvailableToReadWrtie(data::v_io_size maxToRead, data::v_io_si
   m_pipeOut->getWriter()->setMaxAvailableToWrite(maxToWrite);
 }
   
-data::v_io_size Socket::read(void *data, data::v_io_size count) {
+data::v_io_size Socket::read(void *data, v_buff_size count) {
   return m_pipeIn->getReader()->read(data, count);
 }
 
-data::v_io_size Socket::write(const void *data, data::v_io_size count) {
+data::v_io_size Socket::write(const void *data, v_buff_size count) {
   return m_pipeOut->getWriter()->write(data, count);
 }
 

--- a/src/oatpp/network/virtual_/Socket.hpp
+++ b/src/oatpp/network/virtual_/Socket.hpp
@@ -74,7 +74,7 @@ public:
    * @param count - buffer size.
    * @return - actual amount of data read from socket.
    */
-  data::v_io_size read(void *data, data::v_io_size count) override;
+  data::v_io_size read(void *data, v_buff_size count) override;
 
   /**
    * Write data to socket.
@@ -82,7 +82,7 @@ public:
    * @param count - data size.
    * @return - actual amount of data written to socket.
    */
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   /**
    * Implementation of OutputStream must suggest async actions for I/O results.

--- a/src/oatpp/network/virtual_/client/ConnectionProvider.cpp
+++ b/src/oatpp/network/virtual_/client/ConnectionProvider.cpp
@@ -45,11 +45,16 @@ void ConnectionProvider::close() {
 
 std::shared_ptr<ConnectionProvider::IOStream> ConnectionProvider::getConnection() {
   auto submission = m_interface->connect();
-  auto socket = submission->getSocket();
-  socket->setOutputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
-  socket->setInputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
-  socket->setMaxAvailableToReadWrtie(m_maxAvailableToRead, m_maxAvailableToWrite);
-  return socket;
+  if(submission->isValid()) {
+    auto socket = submission->getSocket();
+    if (socket) {
+      socket->setOutputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
+      socket->setInputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
+      socket->setMaxAvailableToReadWrtie(m_maxAvailableToRead, m_maxAvailableToWrite);
+      return socket;
+    }
+  }
+  throw std::runtime_error("[oatpp::network::virtual_::client::getConnection()]: Error. Can't connect. " + m_interface->getName()->std_str());
 }
   
 oatpp::async::CoroutineStarterForResult<const std::shared_ptr<oatpp::data::stream::IOStream>&> ConnectionProvider::getConnectionAsync() {

--- a/src/oatpp/network/virtual_/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/virtual_/server/ConnectionProvider.cpp
@@ -28,6 +28,7 @@ namespace oatpp { namespace network { namespace virtual_ { namespace server {
 
 ConnectionProvider::ConnectionProvider(const std::shared_ptr<virtual_::Interface>& interface)
   : m_interface(interface)
+  , m_listenerLock(interface->bind())
   , m_open(true)
   , m_maxAvailableToRead(-1)
   , m_maxAvailableToWrite(-1)
@@ -47,6 +48,7 @@ void ConnectionProvider::setSocketMaxAvailableToReadWrtie(data::v_io_size maxToR
 
 void ConnectionProvider::close() {
   m_open = false;
+  m_listenerLock.reset();
   m_interface->notifyAcceptors();
 }
 

--- a/src/oatpp/network/virtual_/server/ConnectionProvider.hpp
+++ b/src/oatpp/network/virtual_/server/ConnectionProvider.hpp
@@ -38,6 +38,7 @@ namespace oatpp { namespace network { namespace virtual_ { namespace server {
 class ConnectionProvider : public oatpp::network::ServerConnectionProvider {
 private:
   std::shared_ptr<virtual_::Interface> m_interface;
+  std::shared_ptr<virtual_::Interface::ListenerLock> m_listenerLock;
   bool m_open;
   data::v_io_size m_maxAvailableToRead;
   data::v_io_size m_maxAvailableToWrite;

--- a/src/oatpp/parser/json/Utils.cpp
+++ b/src/oatpp/parser/json/Utils.cpp
@@ -29,9 +29,9 @@
 
 namespace oatpp { namespace parser { namespace json{
 
-v_int64 Utils::calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSize) {
-  v_int64 result = 0;
-  v_int64 i = 0;
+v_buff_size Utils::calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize) {
+  v_buff_size result = 0;
+  v_buff_size i = 0;
   safeSize = size;
   while (i < size) {
     v_char8 a = data[i];
@@ -50,7 +50,7 @@ v_int64 Utils::calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSi
         result ++;
       }
     } else {
-      v_int64 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
+      v_buff_size charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
       if(charSize != 0) {
         if(i + charSize > size) {
           safeSize = i;
@@ -73,10 +73,10 @@ v_int64 Utils::calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSi
   return result;
 }
 
-v_int64 Utils::calcUnescapedStringSize(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition) {
+v_buff_size Utils::calcUnescapedStringSize(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition) {
   errorCode = 0;
-  v_int64 result = 0;
-  v_int64 i = 0;
+  v_buff_size result = 0;
+  v_buff_size i = 0;
   
   while (i < size) {
     v_char8 a = data[i];
@@ -168,8 +168,8 @@ v_int64 Utils::calcUnescapedStringSize(p_char8 data, v_int64 size, v_int64& erro
   return result;
 }
   
-v_int64 Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
-  v_int64 length;
+v_buff_size Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
+  v_buff_size length;
   v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(sequence, length);
   if(code < 0x00010000) {
     buffer[0] = '\\';
@@ -196,16 +196,16 @@ v_int64 Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
   }
 }
   
-oatpp::String Utils::escapeString(p_char8 data, v_int64 size, bool copyAsOwnData) {
-  v_int64 safeSize;
-  v_int64 escapedSize = calcEscapedStringSize(data, size, safeSize);
+oatpp::String Utils::escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData) {
+  v_buff_size safeSize;
+  v_buff_size escapedSize = calcEscapedStringSize(data, size, safeSize);
   if(escapedSize == size) {
     return String((const char*)data, size, copyAsOwnData);
   }
   auto result = String(escapedSize);
-  v_int64 i = 0;
+  v_buff_size i = 0;
   p_char8 resultData = result->getData();
-  v_int64 pos = 0;
+  v_buff_size pos = 0;
   
   while (i < safeSize) {
     v_char8 a = data[i];
@@ -240,7 +240,7 @@ oatpp::String Utils::escapeString(p_char8 data, v_int64 size, bool copyAsOwnData
       }
       i ++;
     } else {
-      v_int64 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
+      v_buff_size charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
       if(charSize != 0) {
         pos += escapeUtf8Char(&data[i], &resultData[pos]);
         i += charSize;
@@ -254,7 +254,7 @@ oatpp::String Utils::escapeString(p_char8 data, v_int64 size, bool copyAsOwnData
   }
   
   if(size > safeSize){
-    for(v_int64 i = pos; i < result->getSize(); i ++){
+    for(v_buff_size i = pos; i < result->getSize(); i ++){
       resultData[i] = '?';
     }
   }
@@ -262,10 +262,10 @@ oatpp::String Utils::escapeString(p_char8 data, v_int64 size, bool copyAsOwnData
   return result;
 }
 
-void Utils::unescapeStringToBuffer(p_char8 data, v_int64 size, p_char8 resultData){
+void Utils::unescapeStringToBuffer(p_char8 data, v_buff_size size, p_char8 resultData){
   
-  v_int64 i = 0;
-  v_int64 pos = 0;
+  v_buff_size i = 0;
+  v_buff_size pos = 0;
   
   while (i < size) {
     v_char8 a = data[i];
@@ -318,9 +318,9 @@ void Utils::unescapeStringToBuffer(p_char8 data, v_int64 size, p_char8 resultDat
   
 }
   
-oatpp::String Utils::unescapeString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition) {
+oatpp::String Utils::unescapeString(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition) {
   
-  v_int64 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
+  v_buff_size unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
   if(errorCode != 0){
     return nullptr;
   }
@@ -334,9 +334,9 @@ oatpp::String Utils::unescapeString(p_char8 data, v_int64 size, v_int64& errorCo
   
 }
   
-std::string Utils::unescapeStringToStdString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition){
+std::string Utils::unescapeStringToStdString(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition){
   
-  v_int64 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
+  v_buff_size unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
   if(errorCode != 0){
     return "";
   }
@@ -351,14 +351,14 @@ std::string Utils::unescapeStringToStdString(p_char8 data, v_int64 size, v_int64
   
 }
   
-p_char8 Utils::preparseString(ParsingCaret& caret, v_int64& size){
+p_char8 Utils::preparseString(ParsingCaret& caret, v_buff_size& size){
   
   if(caret.canContinueAtChar('"', 1)){
     
     const p_char8 data = caret.getData();
-    v_int64 pos = caret.getPosition();
-    v_int64 pos0 = pos;
-    v_int64 length = caret.getDataSize();
+    v_buff_size pos = caret.getPosition();
+    v_buff_size pos0 = pos;
+    v_buff_size length = caret.getDataSize();
     
     while (pos < length) {
       v_char8 a = data[pos];
@@ -383,15 +383,15 @@ p_char8 Utils::preparseString(ParsingCaret& caret, v_int64& size){
   
 oatpp::String Utils::parseString(ParsingCaret& caret) {
   
-  v_int64 size;
+  v_buff_size size;
   p_char8 data = preparseString(caret, size);
   
   if(data != nullptr) {
   
-    v_int64 pos = caret.getPosition();
+    v_buff_size pos = caret.getPosition();
     
     v_int64 errorCode;
-    v_int64 errorPosition;
+    v_buff_size errorPosition;
     auto result = unescapeString(data, size, errorCode, errorPosition);
     if(errorCode != 0){
       caret.setError("[oatpp::parser::json::Utils::parseString()]: Error. Call to unescapeString() failed", errorCode);
@@ -410,15 +410,15 @@ oatpp::String Utils::parseString(ParsingCaret& caret) {
   
 std::string Utils::parseStringToStdString(ParsingCaret& caret){
   
-  v_int64 size;
+  v_buff_size size;
   p_char8 data = preparseString(caret, size);
   
   if(data != nullptr) {
     
-    v_int64 pos = caret.getPosition();
+    v_buff_size pos = caret.getPosition();
     
     v_int64 errorCode;
-    v_int64 errorPosition;
+    v_buff_size errorPosition;
     const std::string& result = unescapeStringToStdString(data, size, errorCode, errorPosition);
     if(errorCode != 0){
       caret.setError("[oatpp::parser::json::Utils::parseStringToStdString()]: Error. Call to unescapeStringToStdString() failed", errorCode);

--- a/src/oatpp/parser/json/Utils.hpp
+++ b/src/oatpp/parser/json/Utils.hpp
@@ -59,11 +59,11 @@ public:
   typedef oatpp::String String;
   typedef oatpp::parser::Caret ParsingCaret;
 private:
-  static v_int64 escapeUtf8Char(p_char8 sequence, p_char8 buffer);
-  static v_int64 calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSize);
-  static v_int64 calcUnescapedStringSize(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
-  static void unescapeStringToBuffer(p_char8 data, v_int64 size, p_char8 resultData);
-  static p_char8 preparseString(ParsingCaret& caret, v_int64& size);
+  static v_buff_size escapeUtf8Char(p_char8 sequence, p_char8 buffer);
+  static v_buff_size calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize);
+  static v_buff_size calcUnescapedStringSize(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition);
+  static void unescapeStringToBuffer(p_char8 data, v_buff_size size, p_char8 resultData);
+  static p_char8 preparseString(ParsingCaret& caret, v_buff_size& size);
 public:
 
   /**
@@ -74,7 +74,7 @@ public:
    * @param copyAsOwnData - see &id:oatpp::base::StrBuffer::StrBuffer;.
    * @return - &id:oatpp::String;.
    */
-  static String escapeString(p_char8 data, v_int64 size, bool copyAsOwnData = true);
+  static String escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData = true);
 
   /**
    * Unescape string as for json standard.
@@ -90,7 +90,7 @@ public:
    * @param errorPosition - out parameter. Error position in data.
    * @return - &id:oatpp::String;.
    */
-  static String unescapeString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
+  static String unescapeString(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition);
 
   /**
    * Same as &l:Utils::unescapeString (); but return `std::string`.
@@ -106,7 +106,7 @@ public:
    * @param errorPosition - out parameter. Error position in data.
    * @return - &id:oatpp::String;.
    */
-  static std::string unescapeStringToStdString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
+  static std::string unescapeStringToStdString(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition);
 
   /**
    * Parse string enclosed in `"<string>"`.

--- a/src/oatpp/parser/json/mapping/Deserializer.cpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.cpp
@@ -32,9 +32,9 @@ namespace oatpp { namespace parser { namespace json { namespace mapping {
 void Deserializer::skipScope(oatpp::parser::Caret& caret, v_char8 charOpen, v_char8 charClose){
   
   p_char8 data = caret.getData();
-  v_int64 size = caret.getDataSize();
-  v_int64 pos = caret.getPosition();
-  v_int64 scopeCounter = 0;
+  v_buff_size size = caret.getDataSize();
+  v_buff_size pos = caret.getPosition();
+  v_int32 scopeCounter = 0;
   
   bool isInString = false;
   
@@ -65,9 +65,9 @@ void Deserializer::skipScope(oatpp::parser::Caret& caret, v_char8 charOpen, v_ch
   
 void Deserializer::skipString(oatpp::parser::Caret& caret){
   p_char8 data = caret.getData();
-  v_int64 size = caret.getDataSize();
-  v_int64 pos = caret.getPosition();
-  v_int64 scopeCounter = 0;
+  v_buff_size size = caret.getDataSize();
+  v_buff_size pos = caret.getPosition();
+  v_int32 scopeCounter = 0;
   while(pos < size){
     v_char8 a = data[pos];
     if(a == '"'){
@@ -85,8 +85,8 @@ void Deserializer::skipString(oatpp::parser::Caret& caret){
   
 void Deserializer::skipToken(oatpp::parser::Caret& caret){
   p_char8 data = caret.getData();
-  v_int64 size = caret.getDataSize();
-  v_int64 pos = caret.getPosition();
+  v_buff_size size = caret.getDataSize();
+  v_buff_size pos = caret.getPosition();
   while(pos < size){
     v_char8 a = data[pos];
     if(a == ' ' || a == '\t' || a == '\n' || a == '\r' || a == '\b' || a == '\f' ||

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -28,7 +28,7 @@
 
 namespace oatpp { namespace parser { namespace json { namespace mapping {
   
-void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int64 size) {
+void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_buff_size size) {
   auto encodedValue = Utils::escapeString(data, size, false);
   stream->writeChar('\"');
   stream->write(encodedValue);

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -47,7 +47,7 @@ void Serializer::writeList(oatpp::data::stream::ConsistentOutputStream* stream, 
   while(curr != nullptr){
     auto value = curr->getData();
     if(value || config->includeNullFields) {
-      (first) ? first = false : stream->write(", ", 2);
+      (first) ? first = false : stream->write(",", 1);
       writeValue(stream, curr->getData(), config);
     }
     curr = curr->getNext();
@@ -64,10 +64,10 @@ void Serializer::writeFieldsMap(oatpp::data::stream::ConsistentOutputStream* str
   while(curr != nullptr){
     auto value = curr->getValue();
     if(value || config->includeNullFields) {
-      (first) ? first = false : stream->write(", ", 2);
+      (first) ? first = false : stream->write(",", 1);
       auto key = curr->getKey();
       writeString(stream, key->getData(), key->getSize());
-      stream->write(": ", 2);
+      stream->write(":", 1);
       writeValue(stream, curr->getValue(), config);
     }
     curr = curr->getNext();
@@ -88,9 +88,9 @@ void Serializer::writeObject(oatpp::data::stream::ConsistentOutputStream* stream
     
     auto value = field->get(object);
     if(value || config->includeNullFields) {
-      (first) ? first = false : stream->write(", ", 2);
+      (first) ? first = false : stream->write(",", 1);
       writeString(stream, field->name);
-      stream->write(": ", 2);
+      stream->write(":", 1);
       writeValue(stream, value, config);
     }
     

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -97,7 +97,7 @@ public:
   
 private:
   
-  static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int64 size);
+  static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_buff_size size);
   static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, const char* data);
   
   template<class T>

--- a/src/oatpp/web/client/ApiClient.cpp
+++ b/src/oatpp/web/client/ApiClient.cpp
@@ -26,8 +26,8 @@
 
 namespace oatpp { namespace web { namespace client {
 
-ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_int64 size, v_int64& position) {
-  for(v_int64 i = position; i < size; i++){
+ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_buff_size size, v_buff_size& position) {
+  for(v_buff_size i = position; i < size; i++){
     v_char8 a = data[i];
     if(a == '{'){
       auto result = PathSegment(std::string((char*) &data[position], i - position), PathSegment::SEG_PATH);
@@ -40,8 +40,8 @@ ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_int64 size, v
   return result;
 }
 
-ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_int64 size, v_int64& position) {
-  for(v_int64 i = position; i < size; i++){
+ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_buff_size size, v_buff_size& position) {
+  for(v_buff_size i = position; i < size; i++){
     v_char8 a = data[i];
     if(a == '}'){
       auto result = PathSegment(std::string((char*) &data[position], i - position), PathSegment::SEG_VAR);
@@ -54,8 +54,8 @@ ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_int64 size, v_
   return result;
 }
   
-ApiClient::PathPattern ApiClient::parsePathPattern(p_char8 data, v_int64 size) {
-  v_int64 pos = 0;
+ApiClient::PathPattern ApiClient::parsePathPattern(p_char8 data, v_buff_size size) {
+  v_buff_size pos = 0;
   PathPattern result;
   while (pos < size) {
     v_char8 a = data[pos];

--- a/src/oatpp/web/client/ApiClient.cpp
+++ b/src/oatpp/web/client/ApiClient.cpp
@@ -146,6 +146,9 @@ oatpp::async::CoroutineStarterForResult<const std::shared_ptr<RequestExecutor::C
   return m_requestExecutor->getConnectionAsync();
 }
 
+void ApiClient::invalidateConnection(const std::shared_ptr<RequestExecutor::ConnectionHandle>& connectionHandle) {
+  m_requestExecutor->invalidateConnection(connectionHandle);
+}
 
 std::shared_ptr<ApiClient::Response> ApiClient::executeRequest(const oatpp::String& method,
                                                                const PathPattern& pathPattern,

--- a/src/oatpp/web/client/ApiClient.hpp
+++ b/src/oatpp/web/client/ApiClient.hpp
@@ -126,15 +126,15 @@ protected:
   
   class PathSegment {
   public:
-    constexpr static const v_int64 SEG_PATH = 0;
-    constexpr static const v_int64 SEG_VAR = 1;
+    constexpr static const v_int32 SEG_PATH = 0;
+    constexpr static const v_int32 SEG_VAR = 1;
   public:
-    PathSegment(const std::string& pText, v_int64 pType)
+    PathSegment(const std::string& pText, v_int32 pType)
       : text (pText)
       , type (pType)
     {}
     const std::string text;
-    const v_int64 type;
+    const v_int32 type;
   };
   
   typedef std::list<PathSegment> PathPattern;
@@ -152,9 +152,9 @@ private:
   
 protected:
   
-  static PathSegment parsePathSegment(p_char8 data, v_int64 size, v_int64& position);
-  static PathSegment parseVarSegment(p_char8 data, v_int64 size, v_int64& position);
-  static PathPattern parsePathPattern(p_char8 data, v_int64 size);
+  static PathSegment parsePathSegment(p_char8 data, v_buff_size size, v_buff_size& position);
+  static PathSegment parseVarSegment(p_char8 data, v_buff_size size, v_buff_size& position);
+  static PathPattern parsePathPattern(p_char8 data, v_buff_size size);
   
 protected:
   std::shared_ptr<RequestExecutor> m_requestExecutor;

--- a/src/oatpp/web/client/ApiClient.hpp
+++ b/src/oatpp/web/client/ApiClient.hpp
@@ -193,6 +193,11 @@ public:
    */
   virtual oatpp::async::CoroutineStarterForResult<const std::shared_ptr<RequestExecutor::ConnectionHandle>&> getConnectionAsync();
 
+  /**
+   * Invalidate connection.
+   * @param connectionHandle
+   */
+  void invalidateConnection(const std::shared_ptr<RequestExecutor::ConnectionHandle>& connectionHandle);
 
   virtual std::shared_ptr<Response> executeRequest(const oatpp::String& method,
                                                    const PathPattern& pathPattern,

--- a/src/oatpp/web/client/HttpRequestExecutor.cpp
+++ b/src/oatpp/web/client/HttpRequestExecutor.cpp
@@ -46,16 +46,19 @@
 namespace oatpp { namespace web { namespace client {
 
 HttpRequestExecutor::HttpRequestExecutor(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+                                         const std::shared_ptr<RetryPolicy>& retryPolicy,
                                          const std::shared_ptr<const BodyDecoder>& bodyDecoder)
-  : m_connectionProvider(connectionProvider)
+  : RequestExecutor(retryPolicy)
+  , m_connectionProvider(connectionProvider)
   , m_bodyDecoder(bodyDecoder)
 {}
 
 std::shared_ptr<HttpRequestExecutor>
 HttpRequestExecutor::createShared(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+                                  const std::shared_ptr<RetryPolicy>& retryPolicy,
                                   const std::shared_ptr<const BodyDecoder>& bodyDecoder)
 {
-  return std::make_shared<HttpRequestExecutor>(connectionProvider, bodyDecoder);
+  return std::make_shared<HttpRequestExecutor>(connectionProvider, retryPolicy, bodyDecoder);
 }
 
 std::shared_ptr<HttpRequestExecutor::ConnectionHandle> HttpRequestExecutor::getConnection() {
@@ -92,24 +95,31 @@ HttpRequestExecutor::getConnectionAsync() {
   return GetConnectionCoroutine::startForResult(m_connectionProvider);
   
 }
+
+void HttpRequestExecutor::invalidateConnection(const std::shared_ptr<ConnectionHandle>& connectionHandle) {
+
+  if(connectionHandle) {
+    auto connection = static_cast<HttpConnectionHandle*>(connectionHandle.get())->connection;
+    m_connectionProvider->invalidateConnection(connection);
+  }
+
+}
   
 std::shared_ptr<HttpRequestExecutor::Response>
-HttpRequestExecutor::execute(const String& method,
-                             const String& path,
-                             const Headers& headers,
-                             const std::shared_ptr<Body>& body,
-                             const std::shared_ptr<ConnectionHandle>& connectionHandle) {
+HttpRequestExecutor::executeOnce(const String& method,
+                                 const String& path,
+                                 const Headers& headers,
+                                 const std::shared_ptr<Body>& body,
+                                 const std::shared_ptr<ConnectionHandle>& connectionHandle) {
   
   std::shared_ptr<oatpp::data::stream::IOStream> connection;
   if(connectionHandle) {
     connection = static_cast<HttpConnectionHandle*>(connectionHandle.get())->connection;
-  } else {
-    connection = m_connectionProvider->getConnection();
   }
-  
+
   if(!connection){
     throw RequestExecutionError(RequestExecutionError::ERROR_CODE_CANT_CONNECT,
-                                "[oatpp::web::client::HttpRequestExecutor::execute()]: ConnectionProvider failed to provide Connection");
+                                "[oatpp::web::client::HttpRequestExecutor::executeOnce()]: Connection is null");
   }
   
   auto request = oatpp::web::protocol::http::outgoing::Request::createShared(method, path, headers, body);
@@ -127,15 +137,15 @@ HttpRequestExecutor::execute(const String& method,
   const auto& result = headerReader.readHeaders(connection, error);
   
   if(error.status.code != 0) {
-    m_connectionProvider->invalidateConnection(connection);
+    invalidateConnection(connectionHandle);
     throw RequestExecutionError(RequestExecutionError::ERROR_CODE_CANT_PARSE_STARTING_LINE,
-                                "[oatpp::web::client::HttpRequestExecutor::execute()]: Failed to parse response. Invalid response headers");
+                                "[oatpp::web::client::HttpRequestExecutor::executeOnce()]: Failed to parse response. Invalid response headers");
   }
   
   if(error.ioStatus < 0) {
-    m_connectionProvider->invalidateConnection(connection);
+    invalidateConnection(connectionHandle);
     throw RequestExecutionError(RequestExecutionError::ERROR_CODE_CANT_PARSE_STARTING_LINE,
-                                "[oatpp::web::client::HttpRequestExecutor::execute()]: Failed to read response.");
+                                "[oatpp::web::client::HttpRequestExecutor::executeOnce()]: Failed to read response.");
   }
   
   auto bodyStream = oatpp::data::stream::InputStreamBufferedProxy::createShared(connection,
@@ -151,11 +161,11 @@ HttpRequestExecutor::execute(const String& method,
 }
 
 oatpp::async::CoroutineStarterForResult<const std::shared_ptr<HttpRequestExecutor::Response>&>
-HttpRequestExecutor::executeAsync(const String& method,
-                                  const String& path,
-                                  const Headers& headers,
-                                  const std::shared_ptr<Body>& body,
-                                  const std::shared_ptr<ConnectionHandle>& connectionHandle) {
+HttpRequestExecutor::executeOnceAsync(const String& method,
+                                      const String& path,
+                                      const Headers& headers,
+                                      const std::shared_ptr<Body>& body,
+                                      const std::shared_ptr<ConnectionHandle>& connectionHandle) {
   
   typedef protocol::http::incoming::ResponseHeadersReader ResponseHeadersReader;
   
@@ -163,7 +173,7 @@ HttpRequestExecutor::executeAsync(const String& method,
   private:
     typedef oatpp::web::protocol::http::outgoing::Request OutgoingRequest;
   private:
-    std::shared_ptr<ClientConnectionProvider> m_connectionProvider;
+    HttpRequestExecutor* m_this;
     String m_method;
     String m_path;
     Headers m_headers;
@@ -176,14 +186,14 @@ HttpRequestExecutor::executeAsync(const String& method,
     oatpp::data::share::MemoryLabel m_buffer;
   public:
     
-    ExecutorCoroutine(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+    ExecutorCoroutine(HttpRequestExecutor* _this,
                       const String& method,
                       const String& path,
                       const Headers& headers,
                       const std::shared_ptr<Body>& body,
                       const std::shared_ptr<const BodyDecoder>& bodyDecoder,
                       const std::shared_ptr<ConnectionHandle>& connectionHandle)
-      : m_connectionProvider(connectionProvider)
+      : m_this(_this)
       , m_method(method)
       , m_path(path)
       , m_headers(headers)
@@ -193,25 +203,23 @@ HttpRequestExecutor::executeAsync(const String& method,
     {}
     
     Action act() override {
+
       if(m_connectionHandle) {
-        /* Careful here onConnectionReady() should have only one possibe state */
-        /* Because it is called here in synchronous manner */
-        return onConnectionReady(static_cast<HttpConnectionHandle*>(m_connectionHandle.get())->connection);
-      } else {
-        return m_connectionProvider->getConnectionAsync().callbackTo(&ExecutorCoroutine::onConnectionReady);
+        m_connection = static_cast<HttpConnectionHandle*>(m_connectionHandle.get())->connection;
       }
-    }
-    
-    /* Careful here onConnectionReady() should have only one possibe state */
-    /* Because there is a call to it from act() in synchronous manner */
-    Action onConnectionReady(const std::shared_ptr<oatpp::data::stream::IOStream>& connection) {
-      m_connection = connection;
+
+      if(!m_connection) {
+        throw RequestExecutionError(RequestExecutionError::ERROR_CODE_CANT_CONNECT,
+                                    "[oatpp::web::client::HttpRequestExecutor::executeOnceAsync::ExecutorCoroutine{act()}]: Connection is null");
+      }
+
       auto request = OutgoingRequest::createShared(m_method, m_path, m_headers, m_body);
-      request->putHeaderIfNotExists(Header::HOST, m_connectionProvider->getProperty("host"));
+      request->putHeaderIfNotExists(Header::HOST, m_this->m_connectionProvider->getProperty("host"));
       request->putHeaderIfNotExists(Header::CONNECTION, Header::Value::CONNECTION_KEEP_ALIVE);
       m_buffer = oatpp::data::share::MemoryLabel(oatpp::base::StrBuffer::createShared(oatpp::data::buffer::IOBuffer::BUFFER_SIZE));
-      m_upstream = oatpp::data::stream::OutputStreamBufferedProxy::createShared(connection, m_buffer);
+      m_upstream = oatpp::data::stream::OutputStreamBufferedProxy::createShared(m_connection, m_buffer);
       return OutgoingRequest::sendAsync(request, m_upstream).next(m_upstream->flushAsync()).next(yieldTo(&ExecutorCoroutine::readResponse));
+
     }
     
     Action readResponse() {
@@ -235,16 +243,17 @@ HttpRequestExecutor::executeAsync(const String& method,
 
     Action handleError(oatpp::async::Error* error) override {
 
-      if(m_connection) {
-        m_connectionProvider->invalidateConnection(m_connection);
+      if(m_connectionHandle) {
+        m_this->invalidateConnection(m_connectionHandle);
       }
 
       return error;
+
     }
     
   };
   
-  return ExecutorCoroutine::startForResult(m_connectionProvider, method, path, headers, body, m_bodyDecoder, connectionHandle);
+  return ExecutorCoroutine::startForResult(this, method, path, headers, body, m_bodyDecoder, connectionHandle);
   
 }
   

--- a/src/oatpp/web/client/HttpRequestExecutor.hpp
+++ b/src/oatpp/web/client/HttpRequestExecutor.hpp
@@ -74,6 +74,7 @@ public:
    * @param bodyDecoder - &id:oatpp::web::protocol::http::incoming::BodyDecoder;.
    */
   HttpRequestExecutor(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+                      const std::shared_ptr<RetryPolicy>& retryPolicy = nullptr,
                       const std::shared_ptr<const BodyDecoder>& bodyDecoder =
                       std::make_shared<oatpp::web::protocol::http::incoming::SimpleBodyDecoder>());
 public:
@@ -86,6 +87,7 @@ public:
    */
   static std::shared_ptr<HttpRequestExecutor>
   createShared(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+               const std::shared_ptr<RetryPolicy>& retryPolicy = nullptr,
                const std::shared_ptr<const BodyDecoder>& bodyDecoder =
                std::make_shared<oatpp::web::protocol::http::incoming::SimpleBodyDecoder>());
 
@@ -102,6 +104,12 @@ public:
   oatpp::async::CoroutineStarterForResult<const std::shared_ptr<HttpRequestExecutor::ConnectionHandle>&> getConnectionAsync() override;
 
   /**
+   * Invalidate connection.
+   * @param connectionHandle
+   */
+  virtual void invalidateConnection(const std::shared_ptr<ConnectionHandle>& connectionHandle) override;
+
+  /**
    * Execute http request.
    * @param method - method ex: ["GET", "POST", "PUT", etc.].
    * @param path - path to resource.
@@ -111,11 +119,11 @@ public:
    * @return - &id:oatpp::web::protocol::http::incoming::Response;.
    * @throws - &id:oatpp::web::client::RequestExecutor::RequestExecutionError;
    */
-  std::shared_ptr<Response> execute(const String& method,
-                                    const String& path,
-                                    const Headers& headers,
-                                    const std::shared_ptr<Body>& body,
-                                    const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) override;
+  std::shared_ptr<Response> executeOnce(const String& method,
+                                        const String& path,
+                                        const Headers& headers,
+                                        const std::shared_ptr<Body>& body,
+                                        const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) override;
 
   /**
    * Same as &l:HttpRequestExecutor::execute (); but Async.
@@ -127,11 +135,11 @@ public:
    * @return - &id:oatpp::async::CoroutineStarterForResult;.
    */
   oatpp::async::CoroutineStarterForResult<const std::shared_ptr<Response>&>
-  executeAsync(const String& method,
-               const String& path,
-               const Headers& headers,
-               const std::shared_ptr<Body>& body,
-               const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) override;
+  executeOnceAsync(const String& method,
+                   const String& path,
+                   const Headers& headers,
+                   const std::shared_ptr<Body>& body,
+                   const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) override;
   
 };
   

--- a/src/oatpp/web/client/RequestExecutor.cpp
+++ b/src/oatpp/web/client/RequestExecutor.cpp
@@ -24,6 +24,9 @@
 
 #include "RequestExecutor.hpp"
 
+#include <thread>
+#include <chrono>
+
 namespace oatpp { namespace web { namespace client {
 
 RequestExecutor::RequestExecutionError::RequestExecutionError(v_int32 errorCode, const char* message, v_int32 readErrorCode)
@@ -43,6 +46,170 @@ const char* RequestExecutor::RequestExecutionError::getMessage() const {
 
 v_int32 RequestExecutor::RequestExecutionError::getReadErrorCode() const {
   return m_readErrorCode;
+}
+
+RequestExecutor::RequestExecutor(const std::shared_ptr<RetryPolicy>& retryPolicy)
+  : m_retryPolicy(retryPolicy)
+{}
+
+std::shared_ptr<RequestExecutor::Response> RequestExecutor::execute(
+  const String& method,
+  const String& path,
+  const Headers& headers,
+  const std::shared_ptr<Body>& body,
+  const std::shared_ptr<ConnectionHandle>& connectionHandle
+) {
+
+  if(!m_retryPolicy) {
+
+    auto ch = connectionHandle;
+    if (!ch) {
+      ch = getConnection();
+    }
+
+    return executeOnce(method, path, headers, body, ch);
+
+  } else {
+
+    RetryPolicy::Context context;
+    auto ch = connectionHandle;
+
+    while(true) {
+
+      context.attempt ++;
+
+      try {
+
+        if (!ch) {
+          ch = getConnection();
+        }
+
+        auto response = executeOnce(method, path, headers, body, ch);
+
+        if(!m_retryPolicy->retryOnResponse(response->getStatusCode(), context) || !m_retryPolicy->canRetry(context)) {
+          return response;
+        }
+
+      } catch (...) {
+        if(!m_retryPolicy->canRetry(context)) {
+          break;
+        }
+      }
+
+      invalidateConnection(ch);
+      ch.reset();
+
+      v_int64 waitMicro = m_retryPolicy->waitForMicroseconds(context);
+      v_int64 tick0 = oatpp::base::Environment::getMicroTickCount();
+      v_int64 tick = tick0;
+      while(tick < tick0 + waitMicro) {
+        std::this_thread::sleep_for(std::chrono::microseconds(tick0 + waitMicro - tick));
+        tick = oatpp::base::Environment::getMicroTickCount();
+      }
+
+    }
+
+  }
+
+  return nullptr;
+
+}
+
+oatpp::async::CoroutineStarterForResult<const std::shared_ptr<RequestExecutor::Response>&>
+RequestExecutor::executeAsync(
+  const String& method,
+  const String& path,
+  const Headers& headers,
+  const std::shared_ptr<Body>& body,
+  const std::shared_ptr<ConnectionHandle>& connectionHandle
+) {
+
+  class ExecutorCoroutine : public oatpp::async::CoroutineWithResult<ExecutorCoroutine, const std::shared_ptr<RequestExecutor::Response>&> {
+  private:
+    RequestExecutor* m_this;
+    String m_method;
+    String m_path;
+    Headers m_headers;
+    std::shared_ptr<Body> m_body;
+    std::shared_ptr<ConnectionHandle> m_connectionHandle;
+    RetryPolicy::Context m_context;
+  public:
+
+    ExecutorCoroutine(RequestExecutor* _this,
+                      const String& method,
+                      const String& path,
+                      const Headers& headers,
+                      const std::shared_ptr<Body>& body,
+                      const std::shared_ptr<ConnectionHandle>& connectionHandle)
+      : m_this(_this)
+      , m_method(method)
+      , m_path(path)
+      , m_headers(headers)
+      , m_body(body)
+      , m_connectionHandle(connectionHandle)
+    {}
+
+    Action act() override {
+
+      if(!m_connectionHandle) {
+        return m_this->getConnectionAsync().callbackTo(&ExecutorCoroutine::onConnection);
+      }
+
+      return yieldTo(&ExecutorCoroutine::execute);
+
+    }
+
+    Action onConnection(const std::shared_ptr<ConnectionHandle>& connectionHandle) {
+      m_connectionHandle = connectionHandle;
+      return yieldTo(&ExecutorCoroutine::execute);
+    }
+
+    Action execute() {
+      m_context.attempt ++;
+      return m_this->executeOnceAsync(m_method, m_path, m_headers, m_body, m_connectionHandle).callbackTo(&ExecutorCoroutine::onResponse);
+    }
+
+    Action onResponse(const std::shared_ptr<RequestExecutor::Response>& response) {
+
+      if( m_this->m_retryPolicy &&
+          m_this->m_retryPolicy->retryOnResponse(response->getStatusCode(), m_context) &&
+          m_this->m_retryPolicy->canRetry(m_context)
+      ) {
+        return yieldTo(&ExecutorCoroutine::retry);
+      }
+
+      return _return(response);
+    }
+
+    Action retry() {
+
+      if(m_connectionHandle) {
+        m_this->invalidateConnection(m_connectionHandle);
+        m_connectionHandle.reset();
+      }
+
+      return waitFor(std::chrono::microseconds(m_this->m_retryPolicy->waitForMicroseconds(m_context))).next(yieldTo(&ExecutorCoroutine::act));
+
+    }
+
+    Action handleError(Error* error) override {
+
+      if(m_this->m_retryPolicy && m_this->m_retryPolicy->canRetry(m_context)) {
+        return yieldTo(&ExecutorCoroutine::retry);
+      }
+
+      if(m_connectionHandle) {
+        m_this->invalidateConnection(m_connectionHandle);
+        m_connectionHandle.reset();
+      }
+
+      return error;
+    }
+
+  };
+
+  return ExecutorCoroutine::startForResult(this, method, path, headers, body, connectionHandle);
+
 }
 
 }}}

--- a/src/oatpp/web/client/RequestExecutor.hpp
+++ b/src/oatpp/web/client/RequestExecutor.hpp
@@ -25,6 +25,8 @@
 #ifndef oatpp_web_client_RequestExecutor_hpp
 #define oatpp_web_client_RequestExecutor_hpp
 
+#include "RetryPolicy.hpp"
+
 #include "oatpp/web/protocol/http/incoming/Response.hpp"
 #include "oatpp/web/protocol/http/outgoing/Body.hpp"
 #include "oatpp/web/protocol/http/Http.hpp"
@@ -144,8 +146,16 @@ public:
     v_int32 getReadErrorCode() const;
     
   };
-  
+
+private:
+  std::shared_ptr<RetryPolicy> m_retryPolicy;
 public:
+
+  /**
+   * Constructor.
+   * @param retryPolicy - &id:oatpp::web::client::RetryPolicy;.
+   */
+  RequestExecutor(const std::shared_ptr<RetryPolicy>& retryPolicy);
 
   /**
    * Virtual destructor.
@@ -165,7 +175,44 @@ public:
   virtual oatpp::async::CoroutineStarterForResult<const std::shared_ptr<ConnectionHandle>&> getConnectionAsync() = 0;
 
   /**
-   * Execute request.
+   * Invalidate connection.
+   * @param connectionHandle
+   */
+  virtual void invalidateConnection(const std::shared_ptr<ConnectionHandle>& connectionHandle) = 0;
+
+  /**
+   * Execute request once without any retries.
+   * @param method - method ex: ["GET", "POST", "PUT", etc.].
+   * @param path - path to resource.
+   * @param headers - headers map &l:RequestExecutor::Headers;.
+   * @param body - `std::shared_ptr` to &l:RequestExecutor::Body; object.
+   * @param connectionHandle - &l:RequestExecutor::ConnectionHandle;
+   * @return - &id:oatpp::web::protocol::http::incoming::Response;.
+   */
+  virtual std::shared_ptr<Response> executeOnce(const String& method,
+                                                const String& path,
+                                                const Headers& headers,
+                                                const std::shared_ptr<Body>& body,
+                                                const std::shared_ptr<ConnectionHandle>& connectionHandle) = 0;
+
+  /**
+   * Same as &l:RequestExecutor::executeOnce (); but Async.
+   * @param method - method ex: ["GET", "POST", "PUT", etc.].
+   * @param path - path to resource.
+   * @param headers - headers map &l:RequestExecutor::Headers;.
+   * @param body - `std::shared_ptr` to &l:RequestExecutor::Body; object.
+   * @param connectionHandle - &l:RequestExecutor::ConnectionHandle;.
+   * @return - &id:oatpp::async::CoroutineStarterForResult;.
+   */
+  virtual oatpp::async::CoroutineStarterForResult<const std::shared_ptr<Response>&>
+  executeOnceAsync(const String& method,
+                   const String& path,
+                   const Headers& headers,
+                   const std::shared_ptr<Body>& body,
+                   const std::shared_ptr<ConnectionHandle>& connectionHandle) = 0;
+
+  /**
+   * Execute request taking into account retry policy.
    * @param method - method ex: ["GET", "POST", "PUT", etc.].
    * @param path - path to resource.
    * @param headers - headers map &l:RequestExecutor::Headers;.
@@ -177,7 +224,7 @@ public:
                                             const String& path,
                                             const Headers& headers,
                                             const std::shared_ptr<Body>& body,
-                                            const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) = 0;
+                                            const std::shared_ptr<ConnectionHandle>& connectionHandle);
 
   /**
    * Same as &l:RequestExecutor::execute (); but Async.
@@ -188,13 +235,13 @@ public:
    * @param connectionHandle - &l:RequestExecutor::ConnectionHandle;.
    * @return - &id:oatpp::async::CoroutineStarterForResult;.
    */
-  virtual oatpp::async::CoroutineStarterForResult<const std::shared_ptr<Response>&>
-  executeAsync(const String& method,
-               const String& path,
-               const Headers& headers,
-               const std::shared_ptr<Body>& body,
-               const std::shared_ptr<ConnectionHandle>& connectionHandle = nullptr) = 0;
-  
+  oatpp::async::CoroutineStarterForResult<const std::shared_ptr<Response>&>
+  virtual executeAsync(const String& method,
+                       const String& path,
+                       const Headers& headers,
+                       const std::shared_ptr<Body>& body,
+                       const std::shared_ptr<ConnectionHandle>& connectionHandle);
+
 };
   
 }}}

--- a/src/oatpp/web/client/RetryPolicy.cpp
+++ b/src/oatpp/web/client/RetryPolicy.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "RetryPolicy.hpp"
+
+namespace oatpp { namespace web { namespace client {
+
+SimpleRetryPolicy::SimpleRetryPolicy(v_int64 maxAttempts,
+                                     const std::chrono::duration<v_int64, std::micro>& delay,
+                                     const std::unordered_set<v_int32>& httpCodes)
+  : m_maxAttempts(maxAttempts)
+  , m_delay(delay.count())
+  , m_httpCodes(httpCodes)
+{}
+
+bool SimpleRetryPolicy::canRetry(const Context& context) {
+  return context.attempt <= m_maxAttempts || m_maxAttempts == -1;
+}
+
+bool SimpleRetryPolicy::retryOnResponse(v_int32 responseStatusCode, const Context& context) {
+  return m_httpCodes.find(responseStatusCode) != m_httpCodes.end();
+}
+
+v_int64 SimpleRetryPolicy::waitForMicroseconds(const Context& context) {
+  return m_delay;
+}
+
+}}}

--- a/src/oatpp/web/client/RetryPolicy.hpp
+++ b/src/oatpp/web/client/RetryPolicy.hpp
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_web_client_RetryPolicy_hpp
+#define oatpp_web_client_RetryPolicy_hpp
+
+#include "oatpp/core/Types.hpp"
+
+#include <unordered_set>
+
+namespace oatpp { namespace web { namespace client {
+
+/**
+ * Class to control retries in RequestExecutor.
+ */
+class RetryPolicy {
+public:
+
+  /**
+   * This structure holds information about request attempts.
+   */
+  struct Context {
+
+    /**
+     * Attempt number.
+     */
+    v_int64 attempt = 0;
+  };
+
+public:
+
+  /**
+   * Virtual destructor.
+   */
+  virtual ~RetryPolicy() = default;
+
+  /**
+   * Check if the context is eligible to retry.
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - `true` - to retry. `false` - do NOT retry.
+   */
+  virtual bool canRetry(const Context& context) = 0;
+
+  /**
+   * Check whether the client should retry for a given response from the server.
+   * @param responseStatusCode - HTTP status code of the response.
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - `true` - to retry. `false` - do NOT retry.
+   */
+  virtual bool retryOnResponse(v_int32 responseStatusCode, const Context& context) = 0;
+
+  /**
+   * How much client should wait before the next attempt?
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - delay in microseconds.
+   */
+  virtual v_int64 waitForMicroseconds(const Context& context) = 0;
+
+};
+
+class SimpleRetryPolicy : public RetryPolicy {
+private:
+  v_int64 m_maxAttempts;
+  v_int64 m_delay;
+  std::unordered_set<v_int32> m_httpCodes;
+public:
+
+  /**
+   * Constructor.
+   * @param maxAttempts - max number of attempts to retry. `-1` - retry infinitely.
+   * @param delay - delay between attempts.
+   * @param httpCodes - set of HTTP codes to retry for.
+   */
+  SimpleRetryPolicy(v_int64 maxAttempts,
+                    const std::chrono::duration<v_int64, std::micro>& delay,
+                    const std::unordered_set<v_int32>& httpCodes = {503});
+
+  /**
+   * Check if the context is eligible to retry.
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - `true` - to retry. `false` - do NOT retry.
+   */
+  bool canRetry(const Context& context) override;
+
+  /**
+   * Check whether the client should retry for a given response from the server. <br>
+   * *This particular implementation returns `true` for codes from the set provided in the constructor*.
+   * @param responseStatusCode - HTTP status code of the response.
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - `true` - to retry. `false` - do NOT retry.
+   */
+  bool retryOnResponse(v_int32 responseStatusCode, const Context& context) override;
+
+  /**
+   * How much client should wait before the next attempt? <br>
+   * *This particular implementation returns the delay passed to the constructor*.
+   * @param context - &l:RetryPolicy::Context ;.
+   * @return - delay in microseconds.
+   */
+  v_int64 waitForMicroseconds(const Context& context) override;
+
+};
+
+}}}
+
+#endif // oatpp_web_client_RetryPolicy_hpp

--- a/src/oatpp/web/mime/multipart/Reader.cpp
+++ b/src/oatpp/web/mime/multipart/Reader.cpp
@@ -57,7 +57,7 @@ void PartsParser::onPartHeaders(const Headers& partHeaders) {
 
 }
 
-void PartsParser::onPartData(p_char8 data, oatpp::data::v_io_size size) {
+void PartsParser::onPartData(p_char8 data, v_buff_size size) {
   if(size > 0) {
     if(m_currReader) {
       m_currReader->onPartData(m_currPart, data, size);
@@ -111,7 +111,7 @@ async::CoroutineStarter AsyncPartsParser::onPartHeadersAsync(const Headers& part
 
 }
 
-async::CoroutineStarter AsyncPartsParser::onPartDataAsync(p_char8 data, oatpp::data::v_io_size size) {
+async::CoroutineStarter AsyncPartsParser::onPartDataAsync(p_char8 data, v_buff_size size) {
   if(size > 0) {
     if(m_currReader) {
       return m_currReader->onPartDataAsync(m_currPart, data, size);
@@ -141,7 +141,7 @@ Reader::Reader(Multipart* multipart)
   , m_parser(multipart->getBoundary(), m_partsParser, nullptr)
 {}
 
-data::v_io_size Reader::write(const void *data, data::v_io_size count) {
+data::v_io_size Reader::write(const void *data, v_buff_size count) {
   m_parser.parseNext((p_char8) data, count);
   return count;
 }

--- a/src/oatpp/web/mime/multipart/Reader.hpp
+++ b/src/oatpp/web/mime/multipart/Reader.hpp
@@ -121,7 +121,7 @@ public:
 
   void onPartHeaders(const Headers& partHeaders) override;
 
-  void onPartData(p_char8 data, oatpp::data::v_io_size size) override;
+  void onPartData(p_char8 data, v_buff_size size) override;
 
   void setPartReader(const oatpp::String& partName, const std::shared_ptr<PartReader>& reader);
 
@@ -160,7 +160,7 @@ public:
 
   async::CoroutineStarter onPartHeadersAsync(const Headers& partHeaders) override;
 
-  async::CoroutineStarter onPartDataAsync(p_char8 data, oatpp::data::v_io_size size) override;
+  async::CoroutineStarter onPartDataAsync(p_char8 data, v_buff_size size) override;
 
   void setPartReader(const oatpp::String& partName, const std::shared_ptr<AsyncPartReader>& reader);
 
@@ -184,7 +184,7 @@ public:
    */
   Reader(Multipart* multipart);
 
-  data::v_io_size write(const void *data, data::v_io_size count) override;
+  data::v_io_size write(const void *data, v_buff_size count) override;
 
   /**
    * Set named part reader. <br>

--- a/src/oatpp/web/mime/multipart/StatefulParser.cpp
+++ b/src/oatpp/web/mime/multipart/StatefulParser.cpp
@@ -40,7 +40,7 @@ void StatefulParser::ListenerCall::setOnHeadersCall() {
   size = 0;
 }
 
-void StatefulParser::ListenerCall::setOnDataCall(p_char8 pData, data::v_io_size pSize) {
+void StatefulParser::ListenerCall::setOnDataCall(p_char8 pData, v_buff_size pSize) {
   callType = CALL_ON_DATA;
   data = pData;
   size = pSize;
@@ -239,7 +239,7 @@ StatefulParser::ListenerCall StatefulParser::parseNext_Headers(data::stream::Asy
   p_char8 data = (p_char8) inlineData.currBufferPtr;
   auto size = inlineData.bytesLeft;
 
-  for(v_int64 i = 0; i < size; i ++) {
+  for(v_buff_size i = 0; i < size; i ++) {
 
     m_headerSectionEndAccumulator <<= 8;
     m_headerSectionEndAccumulator |= data[i];
@@ -309,7 +309,7 @@ StatefulParser::ListenerCall StatefulParser::parseNext_Data(data::stream::AsyncI
 
 }
 
-v_int64 StatefulParser::parseNext(p_char8 data, v_int64 size) {
+v_buff_size StatefulParser::parseNext(p_char8 data, v_buff_size size) {
 
   data::stream::AsyncInlineWriteData inlineData(data, size);
 

--- a/src/oatpp/web/mime/multipart/StatefulParser.hpp
+++ b/src/oatpp/web/mime/multipart/StatefulParser.hpp
@@ -39,13 +39,13 @@ namespace oatpp { namespace web { namespace mime { namespace multipart {
  */
 class StatefulParser {
 private:
-  static constexpr v_int64 STATE_BOUNDARY = 0;
-  static constexpr v_int64 STATE_AFTER_BOUNDARY = 1;
-  static constexpr v_int64 STATE_HEADERS = 2;
-  static constexpr v_int64 STATE_DATA = 3;
-  static constexpr v_int64 STATE_DONE = 4;
+  static constexpr v_int32 STATE_BOUNDARY = 0;
+  static constexpr v_int32 STATE_AFTER_BOUNDARY = 1;
+  static constexpr v_int32 STATE_HEADERS = 2;
+  static constexpr v_int32 STATE_DATA = 3;
+  static constexpr v_int32 STATE_DONE = 4;
 private:
-  static constexpr v_int64 HEADERS_SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+  static constexpr v_word32 HEADERS_SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
 private:
   /**
    * Typedef for headers map. Headers map key is case-insensitive.
@@ -85,7 +85,7 @@ public:
      * @param data - pointer to data.
      * @param size - size of the data in bytes.
      */
-    virtual void onPartData(p_char8 data, oatpp::data::v_io_size size) = 0;
+    virtual void onPartData(p_char8 data, v_buff_size size) = 0;
 
   };
 
@@ -122,7 +122,7 @@ public:
      * @param data - pointer to data.
      * @param size - size of the data in bytes.
      */
-    virtual async::CoroutineStarter onPartDataAsync(p_char8 data, oatpp::data::v_io_size size) = 0;
+    virtual async::CoroutineStarter onPartDataAsync(p_char8 data, v_buff_size size) = 0;
 
   };
 
@@ -131,9 +131,9 @@ private:
   class ListenerCall {
   public:
 
-    static constexpr v_int64 CALL_NONE = 0;
-    static constexpr v_int64 CALL_ON_HEADERS = 1;
-    static constexpr v_int64 CALL_ON_DATA = 2;
+    static constexpr v_int32 CALL_NONE = 0;
+    static constexpr v_int32 CALL_ON_HEADERS = 1;
+    static constexpr v_int32 CALL_ON_DATA = 2;
 
   public:
 
@@ -143,12 +143,12 @@ private:
       , size(0)
     {}
 
-    v_int64 callType;
+    v_int32 callType;
     p_char8 data;
     data::v_io_size size;
 
     void setOnHeadersCall();
-    void setOnDataCall(p_char8 pData, data::v_io_size pSize);
+    void setOnDataCall(p_char8 pData, v_buff_size pSize);
 
     void call(StatefulParser* parser);
     async::CoroutineStarter callAsync(StatefulParser* parser);
@@ -159,9 +159,9 @@ private:
 
 private:
 
-  v_int64 m_state;
+  v_int32 m_state;
   v_int64 m_currPartIndex;
-  v_int64 m_currBoundaryCharIndex;
+  v_buff_size m_currBoundaryCharIndex;
   bool m_checkForBoundary;
   bool m_finishingBoundary;
   bool m_readingBody;
@@ -180,7 +180,7 @@ private:
    * Max length of all headers per one part.
    * Default value = 4096 bytes.
    */
-  v_int64 m_maxPartHeadersSize;
+  v_buff_size m_maxPartHeadersSize;
 
   std::shared_ptr<Listener> m_listener;
   std::shared_ptr<AsyncListener> m_asyncListener;
@@ -215,7 +215,7 @@ public:
    * @return - exact number of parsed bytes. <br>
    * returned value may be less than size given.
    */
-  v_int64 parseNext(p_char8 data, v_int64 size);
+  v_buff_size parseNext(p_char8 data, v_buff_size size);
 
   /**
    * Parse next chunk of bytes in Async-Inline manner.

--- a/src/oatpp/web/protocol/http/Http.cpp
+++ b/src/oatpp/web/protocol/http/Http.cpp
@@ -135,9 +135,9 @@ oatpp::String Range::toString() const {
   oatpp::data::stream::ChunkedBuffer stream;
   stream.write(units->getData(), units->getSize());
   stream.write("=", 1);
-  stream.writeAsString((v_int64) start);
+  stream.writeAsString(start);
   stream.write("-", 1);
-  stream.writeAsString((v_int64) end);
+  stream.writeAsString(end);
   return stream.toString();
 }
 
@@ -180,12 +180,12 @@ oatpp::String ContentRange::toString() const {
   oatpp::data::stream::ChunkedBuffer stream;
   stream.write(units->getData(), units->getSize());
   stream.write(" ", 1);
-  stream.writeAsString((v_int64) start);
+  stream.writeAsString(start);
   stream.write("-", 1);
-  stream.writeAsString((v_int64) end);
+  stream.writeAsString(end);
   stream.write("/", 1);
   if(isSizeKnown) {
-    stream.writeAsString((v_int64) size);
+    stream.writeAsString(size);
   } else {
     stream.write("*", 1);
   }
@@ -258,7 +258,7 @@ oatpp::String HeaderValueData::getTitleParamValue(const data::share::StringKeyLa
 oatpp::data::share::StringKeyLabelCI_FAST Parser::parseHeaderNameLabel(const std::shared_ptr<oatpp::base::StrBuffer>& headersText,
                                                                          oatpp::parser::Caret& caret) {
   p_char8 data = caret.getData();
-  for(v_int64 i = caret.getPosition(); i < caret.getDataSize(); i++) {
+  for(v_buff_size i = caret.getPosition(); i < caret.getDataSize(); i++) {
     v_char8 a = data[i];
     if(a == ':' || a == ' '){
       oatpp::data::share::StringKeyLabelCI_FAST label(headersText, &data[caret.getPosition()], i - caret.getPosition());
@@ -344,7 +344,7 @@ void Parser::parseOneHeader(Headers& headers,
       return;
     }
     caret.skipChar(' ');
-    v_int64 valuePos0 = caret.getPosition();
+    v_buff_size valuePos0 = caret.getPosition();
     caret.findRN();
     headers.put(name, oatpp::data::share::StringKeyLabel(headersText, &caret.getData()[valuePos0], caret.getPosition() - valuePos0));
     caret.skipRN();

--- a/src/oatpp/web/protocol/http/Http.hpp
+++ b/src/oatpp/web/protocol/http/Http.hpp
@@ -513,16 +513,16 @@ private:
 public:
   
   Range(const oatpp::String& pUnits,
-        const oatpp::data::v_io_size& pStart,
-        const oatpp::data::v_io_size& pEnd)
+        v_int64 pStart,
+        v_int64 pEnd)
     : units(pUnits)
     , start(pStart)
     , end(pEnd)
   {}
   
   oatpp::String units;
-  oatpp::data::v_io_size start;
-  oatpp::data::v_io_size end;
+  v_int64 start;
+  v_int64 end;
   
   oatpp::String toString() const;
   
@@ -545,9 +545,9 @@ private:
 public:
   
   ContentRange(const oatpp::String& pUnits,
-               const oatpp::data::v_io_size& pStart,
-               const oatpp::data::v_io_size& pEnd,
-               const oatpp::data::v_io_size& pSize,
+               v_int64 pStart,
+               v_int64 pEnd,
+               v_int64 pSize,
                bool pIsSizeKnown)
     : units(pUnits)
     , start(pStart)
@@ -557,9 +557,9 @@ public:
   {}
   
   oatpp::String units;
-  oatpp::data::v_io_size start;
-  oatpp::data::v_io_size end;
-  oatpp::data::v_io_size size;
+  v_int64 start;
+  v_int64 end;
+  v_int64 size;
   bool isSizeKnown;
   
   oatpp::String toString() const;

--- a/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
+++ b/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
@@ -35,7 +35,7 @@ data::v_io_size RequestHeadersReader::readHeadersSection(data::stream::InputStre
   data::v_io_size res;
   while (true) {
     
-    v_int64 desiredToRead = m_readChunkSize;
+    v_buff_size desiredToRead = m_readChunkSize;
     if(m_bufferStream->getCurrentPosition() + desiredToRead > m_maxHeadersSize) {
       desiredToRead = m_maxHeadersSize - m_bufferStream->getCurrentPosition();
       if(desiredToRead <= 0) {
@@ -50,7 +50,7 @@ data::v_io_size RequestHeadersReader::readHeadersSection(data::stream::InputStre
 
       m_bufferStream->setCurrentPosition(m_bufferStream->getCurrentPosition() + res);
 
-      for(v_int64 i = 0; i < res; i ++) {
+      for(v_buff_size i = 0; i < res; i ++) {
         accumulator <<= 8;
         accumulator |= bufferData[i];
         if(accumulator == SECTION_END) {
@@ -117,7 +117,7 @@ RequestHeadersReader::readHeadersAsync(const std::shared_ptr<data::stream::Input
     
     Action act() override {
       
-      v_int64 desiredToRead = m_this->m_readChunkSize;
+      v_buff_size desiredToRead = m_this->m_readChunkSize;
       if(m_this->m_bufferStream->getCurrentPosition() + desiredToRead > m_this->m_maxHeadersSize) {
         desiredToRead = m_this->m_maxHeadersSize - m_this->m_bufferStream->getCurrentPosition();
         if(desiredToRead <= 0) {
@@ -132,7 +132,7 @@ RequestHeadersReader::readHeadersAsync(const std::shared_ptr<data::stream::Input
 
         m_this->m_bufferStream->setCurrentPosition(m_this->m_bufferStream->getCurrentPosition() + res);
         
-        for(v_int64 i = 0; i < res; i ++) {
+        for(v_buff_size i = 0; i < res; i ++) {
           m_accumulator <<= 8;
           m_accumulator |= bufferData[i];
           if(m_accumulator == SECTION_END) {

--- a/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.hpp
+++ b/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.hpp
@@ -42,7 +42,7 @@ public:
    */
   typedef oatpp::async::Action Action;
 private:
-  static constexpr v_int32 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+  static constexpr v_word32 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
 public:
 
   /**
@@ -65,8 +65,8 @@ private:
   data::v_io_size readHeadersSection(data::stream::InputStreamBufferedProxy* stream, Result& result);
 private:
   oatpp::data::stream::BufferOutputStream* m_bufferStream;
-  v_int32 m_readChunkSize;
-  v_int32 m_maxHeadersSize;
+  v_buff_size m_readChunkSize;
+  v_buff_size m_maxHeadersSize;
 public:
 
   /**
@@ -75,8 +75,8 @@ public:
    * @param maxHeadersSize
    */
   RequestHeadersReader(oatpp::data::stream::BufferOutputStream* bufferStream,
-                       v_int32 readChunkSize = 2048,
-                       v_int32 maxHeadersSize = 4096)
+                       v_buff_size readChunkSize = 2048,
+                       v_buff_size maxHeadersSize = 4096)
     : m_bufferStream(bufferStream)
     , m_readChunkSize(readChunkSize)
     , m_maxHeadersSize(maxHeadersSize)

--- a/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.cpp
+++ b/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.cpp
@@ -31,14 +31,13 @@ namespace oatpp { namespace web { namespace protocol { namespace http { namespac
 data::v_io_size ResponseHeadersReader::readHeadersSection(const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
                                                                   oatpp::data::stream::OutputStream* bufferStream,
                                                                   Result& result) {
-  
-  v_word32 sectionEnd = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+
   v_word32 accumulator = 0;
-  v_int64 progress = 0;
+  v_buff_size progress = 0;
   data::v_io_size res;
   while (true) {
     
-    v_int64 desiredToRead = m_buffer.getSize();
+    v_buff_size desiredToRead = m_buffer.getSize();
     if(progress + desiredToRead > m_maxHeadersSize) {
       desiredToRead = m_maxHeadersSize - progress;
       if(desiredToRead <= 0) {
@@ -51,10 +50,10 @@ data::v_io_size ResponseHeadersReader::readHeadersSection(const std::shared_ptr<
     if(res > 0) {
       bufferStream->write(bufferData, res);
       
-      for(v_int64 i = 0; i < res; i ++) {
+      for(v_buff_size i = 0; i < res; i ++) {
         accumulator <<= 8;
         accumulator |= bufferData[i];
-        if(accumulator == sectionEnd) {
+        if(accumulator == SECTION_END) {
           result.bufferPosStart = i + 1;
           result.bufferPosEnd = res;
           return res;
@@ -103,15 +102,15 @@ ResponseHeadersReader::readHeadersAsync(const std::shared_ptr<oatpp::data::strea
   private:
     std::shared_ptr<oatpp::data::stream::IOStream> m_connection;
     oatpp::data::share::MemoryLabel m_buffer;
-    v_int64 m_maxHeadersSize;
+    v_buff_size m_maxHeadersSize;
     v_word32 m_accumulator;
-    v_int64 m_progress;
+    v_buff_size m_progress;
     ResponseHeadersReader::Result m_result;
     oatpp::data::stream::ChunkedBuffer m_bufferStream;
   public:
     
     ReaderCoroutine(const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
-                    const oatpp::data::share::MemoryLabel buffer, v_int64 maxHeadersSize)
+                    const oatpp::data::share::MemoryLabel buffer, v_buff_size maxHeadersSize)
     : m_connection(connection)
     , m_buffer(buffer)
     , m_maxHeadersSize(maxHeadersSize)
@@ -121,7 +120,7 @@ ResponseHeadersReader::readHeadersAsync(const std::shared_ptr<oatpp::data::strea
     
     Action act() override {
       
-      v_int64 desiredToRead = m_buffer.getSize();
+      v_buff_size desiredToRead = m_buffer.getSize();
       if(m_progress + desiredToRead > m_maxHeadersSize) {
         desiredToRead = m_maxHeadersSize - m_progress;
         if(desiredToRead <= 0) {
@@ -134,7 +133,7 @@ ResponseHeadersReader::readHeadersAsync(const std::shared_ptr<oatpp::data::strea
         m_bufferStream.write(bufferData, res);
         m_progress += res;
         
-        for(v_int64 i = 0; i < res; i ++) {
+        for(v_buff_size i = 0; i < res; i ++) {
           m_accumulator <<= 8;
           m_accumulator |= bufferData[i];
           if(m_accumulator == SECTION_END) {

--- a/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.hpp
+++ b/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.hpp
@@ -40,7 +40,7 @@ public:
    */
   typedef oatpp::async::Action Action;
 private:
-  static constexpr v_int64 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+  static constexpr v_word32 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
 public:
 
   /**
@@ -60,12 +60,12 @@ public:
     /**
      * This value represents starting position in buffer used to read data from stream for the last read operation.
      */
-    v_int64 bufferPosStart;
+    v_buff_size bufferPosStart;
 
     /**
      * This value represents end position in buffer used to read data from stream for the last read operation.
      */
-    v_int64 bufferPosEnd;
+    v_buff_size bufferPosEnd;
   };
 
 private:
@@ -74,7 +74,7 @@ private:
                                              Result& result);
 private:
   oatpp::data::share::MemoryLabel m_buffer;
-  v_int64 m_maxHeadersSize;
+  v_buff_size m_maxHeadersSize;
 public:
 
   /**
@@ -82,7 +82,7 @@ public:
    * @param buffer - buffer to use to read data from stream. &id:oatpp::data::share::MemoryLabel;.
    * @param maxHeadersSize
    */
-  ResponseHeadersReader(const oatpp::data::share::MemoryLabel& buffer, v_int64 maxHeadersSize)
+  ResponseHeadersReader(const oatpp::data::share::MemoryLabel& buffer, v_buff_size maxHeadersSize)
     : m_buffer(buffer)
     , m_maxHeadersSize(maxHeadersSize)
   {}

--- a/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.cpp
+++ b/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.cpp
@@ -31,11 +31,11 @@ namespace oatpp { namespace web { namespace protocol { namespace http { namespac
   
 data::v_io_size SimpleBodyDecoder::readLine(oatpp::data::stream::InputStream* fromStream,
                                             p_char8 buffer,
-                                            data::v_io_size maxLineSize)
+                                            v_buff_size maxLineSize)
 {
   
   v_char8 a;
-  data::v_io_size count = 0;
+  v_buff_size count = 0;
   while (fromStream->read(&a, 1) > 0) {
     if(a != '\r') {
       if(count + 1 > maxLineSize) {
@@ -63,7 +63,7 @@ void SimpleBodyDecoder::doChunkedDecoding(oatpp::data::stream::InputStream* from
   
   const v_int32 maxLineSize = 8; // 0xFFFFFFFF 4Gb for chunk
   v_char8 lineBuffer[maxLineSize + 1];
-  data::v_io_size countToRead;
+  v_buff_size countToRead;
   
   do {
     
@@ -196,7 +196,7 @@ oatpp::async::CoroutineStarter SimpleBodyDecoder::doChunkedDecodingAsync(const s
     }
     
     Action onLineRead() {
-      data::v_io_size countToRead = strtol((const char*) m_lineBuffer, nullptr, 16);
+      v_buff_size countToRead = strtol((const char*) m_lineBuffer, nullptr, 16);
       if(countToRead > 0) {
         prepareSkipRN();
         return oatpp::data::stream::transferAsync(m_fromStream, m_writeCallback, countToRead, m_buffer).next(yieldTo(&ChunkedDecoder::skipRN));

--- a/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.hpp
+++ b/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.hpp
@@ -34,7 +34,7 @@ namespace oatpp { namespace web { namespace protocol { namespace http { namespac
  */
 class SimpleBodyDecoder : public BodyDecoder {
 private:
-  static data::v_io_size readLine(data::stream::InputStream* fromStream, p_char8 buffer, data::v_io_size maxLineSize);
+  static data::v_io_size readLine(data::stream::InputStream* fromStream, p_char8 buffer, v_buff_size maxLineSize);
 
   static void doChunkedDecoding(data::stream::InputStream* from, data::stream::WriteCallback* writeCallback);
   

--- a/src/oatpp/web/protocol/http/outgoing/Body.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/Body.hpp
@@ -76,7 +76,7 @@ public:
    * If body size is unknown then should return -1.
    * @return - &id:oatpp::data::v_io_size;.
    */
-  virtual data::v_io_size getKnownSize() = 0;
+  virtual v_buff_size getKnownSize() = 0;
   
 };
   

--- a/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
@@ -59,7 +59,7 @@ oatpp::async::CoroutineStarter BufferBody::writeToStreamAsync(const std::shared_
   return WriteToStreamCoroutine::start(shared_from_this(), stream);
 }
 
-data::v_io_size BufferBody::getKnownSize() {
+v_buff_size BufferBody::getKnownSize() {
   return m_buffer->getSize();
 }
 

--- a/src/oatpp/web/protocol/http/outgoing/BufferBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/BufferBody.hpp
@@ -65,9 +65,9 @@ public:
 
   /**
    * Return known size of the body.
-   * @return - &id:oatpp::data::v_io_size;.
+   * @return - `v_buff_size`.
    */
-  data::v_io_size getKnownSize() override;
+  v_buff_size getKnownSize() override;
   
 public:
 

--- a/src/oatpp/web/protocol/http/outgoing/ChunkedBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/ChunkedBody.cpp
@@ -31,7 +31,7 @@ namespace oatpp { namespace web { namespace protocol { namespace http { namespac
 
 ChunkedBody::ChunkedBody(const std::shared_ptr<ReadCallback>& readCallback,
                          const std::shared_ptr<AsyncReadCallback>& asyncReadCallback,
-                         data::v_io_size chunkBufferSize)
+                         v_buff_size chunkBufferSize)
   : m_readCallback(readCallback)
   , m_asyncReadCallback(asyncReadCallback)
   , m_buffer(new v_char8[chunkBufferSize])
@@ -42,7 +42,7 @@ ChunkedBody::~ChunkedBody() {
   delete [] m_buffer;
 }
 
-bool ChunkedBody::writeData(OutputStream* stream, const void* data, data::v_io_size size) {
+bool ChunkedBody::writeData(OutputStream* stream, const void* data, v_buff_size size) {
   return oatpp::data::stream::writeExactSizeData(stream, data, size) == size;
 }
 
@@ -120,7 +120,7 @@ oatpp::async::CoroutineStarter ChunkedBody::writeToStreamAsync(const std::shared
 
     Action onChunkRead() {
 
-      data::v_io_size bytesRead = m_body->m_bufferSize - m_inlineReadData.bytesLeft;
+      v_buff_size bytesRead = m_body->m_bufferSize - m_inlineReadData.bytesLeft;
 
       if(bytesRead > 0) {
 
@@ -170,7 +170,7 @@ oatpp::async::CoroutineStarter ChunkedBody::writeToStreamAsync(const std::shared
 
 }
 
-data::v_io_size ChunkedBody::getKnownSize() {
+v_buff_size ChunkedBody::getKnownSize() {
   return -1;
 }
 

--- a/src/oatpp/web/protocol/http/outgoing/ChunkedBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/ChunkedBody.hpp
@@ -46,12 +46,12 @@ public:
    */
   typedef oatpp::data::stream::AsyncReadCallback AsyncReadCallback;
 private:
-  bool writeData(OutputStream* stream, const void* data, data::v_io_size size);
+  bool writeData(OutputStream* stream, const void* data, v_buff_size size);
 private:
   std::shared_ptr<ReadCallback> m_readCallback;
   std::shared_ptr<AsyncReadCallback> m_asyncReadCallback;
   p_char8 m_buffer;
-  data::v_io_size m_bufferSize;
+  v_buff_size m_bufferSize;
 public:
 
   /**
@@ -62,7 +62,7 @@ public:
    */
   ChunkedBody(const std::shared_ptr<ReadCallback>& readCallback,
               const std::shared_ptr<AsyncReadCallback>& asyncReadCallback,
-              data::v_io_size chunkBufferSize);
+              v_buff_size chunkBufferSize);
 
   /**
    * virtual destructor.
@@ -92,7 +92,7 @@ public:
    * Body size of chunked body is unknown.
    * @return - `-1`. &id:oatpp::data::v_io_size;.
    */
-  data::v_io_size getKnownSize() override;
+  v_buff_size getKnownSize() override;
 
 };
 

--- a/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.cpp
@@ -46,7 +46,7 @@ oatpp::async::CoroutineStarter ChunkedBufferBody::writeToStreamAsync(const std::
   return m_buffer->flushToStreamAsync(stream);
 }
 
-data::v_io_size ChunkedBufferBody::getKnownSize() {
+v_buff_size ChunkedBufferBody::getKnownSize() {
   return m_buffer->getSize();
 }
 

--- a/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.hpp
@@ -78,9 +78,9 @@ public:
 
   /**
    * Return known size of the body.
-   * @return - &id:oatpp::data::v_io_size;.
+   * @return - `v_buff_size`.
    */
-  data::v_io_size getKnownSize() override;
+  v_buff_size getKnownSize() override;
   
 };
   

--- a/src/oatpp/web/protocol/http/outgoing/DtoBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/DtoBody.cpp
@@ -46,7 +46,7 @@ void DtoBody::declareHeaders(Headers& headers) noexcept {
   headers.putIfNotExists(Header::CONTENT_TYPE, m_objectMapper->getInfo().http_content_type);
 }
 
-data::v_io_size DtoBody::getKnownSize() {
+v_buff_size DtoBody::getKnownSize() {
   return m_buffer->getSize();
 }
 

--- a/src/oatpp/web/protocol/http/outgoing/DtoBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/DtoBody.hpp
@@ -74,9 +74,9 @@ public:
 
   /**
    * Return known size of the body.
-   * @return - &id:oatpp::data::v_io_size;.
+   * @return - `v_buff_size`.
    */
-  data::v_io_size getKnownSize() override;
+  v_buff_size getKnownSize() override;
   
 };
 

--- a/src/oatpp/web/protocol/http/outgoing/MultipartBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/MultipartBody.cpp
@@ -38,7 +38,7 @@ MultipartBody::MultipartReadCallback::MultipartReadCallback(const std::shared_pt
   , m_readStream(nullptr, nullptr, 0)
 {}
 
-data::v_io_size MultipartBody::MultipartReadCallback::readBody(void *buffer, data::v_io_size count) {
+data::v_io_size MultipartBody::MultipartReadCallback::readBody(void *buffer, v_buff_size count) {
   auto& part = *m_iterator;
   const auto& stream = part->getInputStream();
   if(!stream) {
@@ -53,7 +53,7 @@ data::v_io_size MultipartBody::MultipartReadCallback::readBody(void *buffer, dat
   return res;
 }
 
-data::v_io_size MultipartBody::MultipartReadCallback::read(void *buffer, data::v_io_size count) {
+data::v_io_size MultipartBody::MultipartReadCallback::read(void *buffer, v_buff_size count) {
 
   if(m_state == STATE_FINISHED) {
     return 0;
@@ -244,7 +244,7 @@ data::v_io_size MultipartBody::readBoundary(const std::shared_ptr<Multipart>& mu
                                             std::list<std::shared_ptr<Part>>::const_iterator& iterator,
                                             data::stream::BufferInputStream& readStream,
                                             void *buffer,
-                                            data::v_io_size count)
+                                            v_buff_size count)
 {
   if (!readStream.getDataMemoryHandle()) {
 
@@ -274,7 +274,7 @@ data::v_io_size MultipartBody::readHeaders(const std::shared_ptr<Multipart>& mul
                                            std::list<std::shared_ptr<Part>>::const_iterator& iterator,
                                            data::stream::BufferInputStream& readStream,
                                            void *buffer,
-                                           data::v_io_size count)
+                                           v_buff_size count)
 {
   (void) multipart;
 
@@ -327,7 +327,7 @@ oatpp::async::CoroutineStarter MultipartBody::writeToStreamAsync(const std::shar
   return ChunkedBody::writeToStreamAsync(stream);
 }
 
-data::v_io_size MultipartBody::getKnownSize() {
+v_buff_size MultipartBody::getKnownSize() {
  return -1;
 }
 

--- a/src/oatpp/web/protocol/http/outgoing/MultipartBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/MultipartBody.hpp
@@ -71,13 +71,13 @@ private:
                                       std::list<std::shared_ptr<Part>>::const_iterator& iterator,
                                       data::stream::BufferInputStream& readStream,
                                       void *buffer,
-                                      data::v_io_size count);
+                                      v_buff_size count);
 
   static data::v_io_size readHeaders(const std::shared_ptr<Multipart>& multipart,
                                      std::list<std::shared_ptr<Part>>::const_iterator& iterator,
                                      data::stream::BufferInputStream& readStream,
                                      void *buffer,
-                                     data::v_io_size count);
+                                     v_buff_size count);
 private:
 
   class MultipartReadCallback : public ReadCallback {
@@ -87,12 +87,12 @@ private:
     v_int32 m_state;
     oatpp::data::stream::BufferInputStream m_readStream;
   private:
-    data::v_io_size readBody(void *buffer, data::v_io_size count);
+    data::v_io_size readBody(void *buffer, v_buff_size count);
   public:
 
     MultipartReadCallback(const std::shared_ptr<Multipart>& multipart);
 
-    data::v_io_size read(void *buffer, data::v_io_size count) override;
+    data::v_io_size read(void *buffer, v_buff_size count) override;
 
   };
 
@@ -149,9 +149,9 @@ public:
 
   /**
    * Always returns `-1` - as body size is unknown.
-   * @return - `-1`. &id:oatpp::data::v_io_size;.
+   * @return - `-1`. `v_buff_size`.
    */
-  data::v_io_size getKnownSize() override;
+  v_buff_size getKnownSize() override;
 
 };
 

--- a/src/oatpp/web/url/mapping/Pattern.cpp
+++ b/src/oatpp/web/url/mapping/Pattern.cpp
@@ -32,7 +32,7 @@ const char* Pattern::Part::FUNCTION_CONST = "const";
 const char* Pattern::Part::FUNCTION_VAR = "var";
 const char* Pattern::Part::FUNCTION_ANY_END = "tail";
 
-std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int64 size){
+std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_buff_size size){
   
   if(size <= 0){
     return nullptr;
@@ -40,8 +40,8 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int64 size){
   
   auto result = Pattern::createShared();
 
-  v_int64 lastPos = 0;
-  v_int64 i = 0;
+  v_buff_size lastPos = 0;
+  v_buff_size i = 0;
   
   while(i < size){
     
@@ -62,7 +62,7 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int64 size){
         auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String((const char*)&data[lastPos], size - lastPos, true));
         result->m_parts->pushBack(part);
       }else{
-        auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String((v_int64)0));
+        auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String((v_buff_size)0));
         result->m_parts->pushBack(part);
       }
       return result;
@@ -78,7 +78,7 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int64 size){
         auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String((const char*)&data[lastPos], i - lastPos, true));
         result->m_parts->pushBack(part);
       }else{
-        auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String((v_int64)0));
+        auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String((v_buff_size)0));
         result->m_parts->pushBack(part);
       }
       
@@ -108,7 +108,7 @@ std::shared_ptr<Pattern> Pattern::parse(const oatpp::String& data){
   
 v_char8 Pattern::findSysChar(oatpp::parser::Caret& caret) {
   auto data = caret.getData();
-  for (v_int64 i = caret.getPosition(); i < caret.getDataSize(); i++) {
+  for (v_buff_size i = caret.getPosition(); i < caret.getDataSize(); i++) {
     v_char8 a = data[i];
     if(a == '/' || a == '?') {
       caret.setPosition(i);

--- a/src/oatpp/web/url/mapping/Pattern.hpp
+++ b/src/oatpp/web/url/mapping/Pattern.hpp
@@ -107,7 +107,7 @@ public:
     return std::make_shared<Pattern>();
   }
   
-  static std::shared_ptr<Pattern> parse(p_char8 data, v_int64 size);
+  static std::shared_ptr<Pattern> parse(p_char8 data, v_buff_size size);
   static std::shared_ptr<Pattern> parse(const char* data);
   static std::shared_ptr<Pattern> parse(const oatpp::String& data);
   

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,8 @@ add_executable(oatppAllTests
         oatpp/web/server/api/ApiControllerTest.hpp
         oatpp/web/server/handler/AuthorizationHandlerTest.cpp
         oatpp/web/server/handler/AuthorizationHandlerTest.hpp
+        oatpp/web/ClientRetryTest.cpp
+        oatpp/web/ClientRetryTest.hpp
         oatpp/web/PipelineTest.cpp
         oatpp/web/PipelineTest.hpp
         oatpp/web/PipelineAsyncTest.cpp

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -1,4 +1,6 @@
 
+#include "oatpp/web/ClientRetryTest.hpp"
+
 #include "oatpp/web/FullTest.hpp"
 #include "oatpp/web/FullAsyncTest.hpp"
 #include "oatpp/web/FullAsyncClientTest.hpp"
@@ -146,6 +148,16 @@ void runTests() {
 
     oatpp::test::web::FullAsyncClientTest test_port(8000, 10);
     test_port.run(1);
+
+  }
+
+  {
+
+    oatpp::test::web::ClientRetryTest test_virtual(0);
+    test_virtual.run();
+
+    oatpp::test::web::ClientRetryTest test_port(8000);
+    test_port.run();
 
   }
 

--- a/test/oatpp/core/async/LockTest.cpp
+++ b/test/oatpp/core/async/LockTest.cpp
@@ -132,13 +132,13 @@ void testMethod(char symbol, Buff *buff, oatpp::async::Lock *lock) {
 
 }
 
-bool checkSymbol(char symbol, const char* data, v_int64 size) {
+bool checkSymbol(char symbol, const char* data, v_buff_size size) {
 
-  for (v_int64 i = 0; i < size; i++) {
+  for (v_buff_size i = 0; i < size; i++) {
 
     if (data[i] == symbol && size - i >= NUM_SYMBOLS) {
 
-      for (v_int64 j = 0; j < NUM_SYMBOLS; j++) {
+      for (v_buff_size j = 0; j < NUM_SYMBOLS; j++) {
 
         if (data[i + j] != symbol) {
           OATPP_LOGD("aaa", "j pos=%d", j);

--- a/test/oatpp/encoding/UnicodeTest.cpp
+++ b/test/oatpp/encoding/UnicodeTest.cpp
@@ -61,14 +61,14 @@ void writeBinaryInt(v_int32 value){
 void UnicodeTest::onRun(){
   
   v_char8 buff[128];
-  v_int64 cnt;
+  v_buff_size cnt;
 
   // 2 byte test
   
   for(v_int32 c = 128; c < 2048; c ++){
-    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    auto size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 2);
-    v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
+    auto code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 2);
     OATPP_ASSERT(code == c);
   }
@@ -76,9 +76,9 @@ void UnicodeTest::onRun(){
   // 3 byte test
   
   for(v_int32 c = 2048; c < 65536; c ++){
-    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    auto size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 3);
-    v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
+    auto code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 3);
     OATPP_ASSERT(code == c);
   }
@@ -86,9 +86,9 @@ void UnicodeTest::onRun(){
   // 4 byte test
   
   for(v_int32 c = 65536; c < 2097152; c ++){
-    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    auto size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 4);
-    v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
+    auto code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 4);
     OATPP_ASSERT(code == c);
   }
@@ -96,9 +96,9 @@ void UnicodeTest::onRun(){
   // 5 byte test
   
   for(v_int32 c = 2097152; c < 67108864; c ++){
-    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    auto size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 5);
-    v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
+    auto code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 5);
     OATPP_ASSERT(code == c);
   }
@@ -106,9 +106,9 @@ void UnicodeTest::onRun(){
   // 6 byte test
 
   for (v_int64 c = 67108864; c < 2147483647; c = c + 100) {
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char((v_int32) c, buff);
+    auto size = oatpp::encoding::Unicode::decodeUtf8Char((v_int32) c, buff);
     OATPP_ASSERT(size == 6);
-    v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
+    auto code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 6);
     OATPP_ASSERT(code == c);
   }
@@ -116,12 +116,12 @@ void UnicodeTest::onRun(){
   // */
   
   p_char8 sequence = (p_char8)"𐐷";
-  v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(sequence, cnt);
+  auto code = oatpp::encoding::Unicode::encodeUtf8Char(sequence, cnt);
   
   v_int16 high;
   v_int16 low;
   oatpp::encoding::Unicode::codeToUtf16SurrogatePair(code, high, low);
-  v_int32 check = oatpp::encoding::Unicode::utf16SurrogatePairToCode(high, low);
+  auto check = oatpp::encoding::Unicode::utf16SurrogatePairToCode(high, low);
   writeBinaryInt(code);
   writeBinaryInt(check);
   OATPP_ASSERT(code == check);

--- a/test/oatpp/encoding/UnicodeTest.cpp
+++ b/test/oatpp/encoding/UnicodeTest.cpp
@@ -104,14 +104,15 @@ void UnicodeTest::onRun(){
   }
   
   // 6 byte test
-  
-  for(v_int32 c = 67108864; c < 2147483647; c ++){
-    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+
+  for (v_int64 c = 67108864; c < 2147483647; c = c + 100) {
+    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char((v_int32) c, buff);
     OATPP_ASSERT(size == 6);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 6);
     OATPP_ASSERT(code == c);
   }
+
   // */
   
   p_char8 sequence = (p_char8)"𐐷";

--- a/test/oatpp/network/ConnectionPoolTest.cpp
+++ b/test/oatpp/network/ConnectionPoolTest.cpp
@@ -36,11 +36,11 @@ typedef oatpp::network::ConnectionPool ConnectionPool;
 class StubStream : public oatpp::data::stream::IOStream, public oatpp::base::Countable {
 public:
 
-  data::v_io_size write(const void *buff, data::v_io_size count) override {
+  data::v_io_size write(const void *buff, v_buff_size count) override {
     throw std::runtime_error("It's a stub!");
   }
 
-  data::v_io_size read(void *buff, data::v_io_size count) override {
+  data::v_io_size read(void *buff, v_buff_size count) override {
     throw std::runtime_error("It's a stub!");
   }
 

--- a/test/oatpp/network/ConnectionPoolTest.cpp
+++ b/test/oatpp/network/ConnectionPoolTest.cpp
@@ -137,7 +137,7 @@ public:
   Action useConnection() {
     if(m_repeats < 1) {
       m_repeats ++;
-      return waitRepeat(std::chrono::milliseconds(100));
+      return waitFor(std::chrono::milliseconds(100)).next(yieldTo(&ClientCoroutine::useConnection));
     }
     if(m_invalidate) {
       m_connection->invalidate();

--- a/test/oatpp/network/virtual_/InterfaceTest.cpp
+++ b/test/oatpp/network/virtual_/InterfaceTest.cpp
@@ -137,6 +137,8 @@ void InterfaceTest::onRun() {
   oatpp::String dataSample = "1234567890-=][poiuytrewqasdfghjkl;'/.,mnbvcxzzxcvbnm,./';lkjhgfdsaqwertyuiop][=-0987654321";
   
   auto interface = Interface::obtainShared("virtualhost");
+  auto bindLock = interface->bind();
+
   v_int32 numTasks = 100;
   
   ThreadList threadList;

--- a/test/oatpp/network/virtual_/PipeTest.cpp
+++ b/test/oatpp/network/virtual_/PipeTest.cpp
@@ -40,7 +40,7 @@ namespace {
   typedef oatpp::network::virtual_::Pipe Pipe;
   
   const char* DATA_CHUNK = "<0123456789/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ>";
-  const data::v_io_size CHUNK_SIZE = std::strlen(DATA_CHUNK);
+  const v_buff_size CHUNK_SIZE = std::strlen(DATA_CHUNK);
 
   class WriterTask : public oatpp::base::Countable {
   private:

--- a/test/oatpp/web/ClientRetryTest.cpp
+++ b/test/oatpp/web/ClientRetryTest.cpp
@@ -1,0 +1,285 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "ClientRetryTest.hpp"
+
+#include "oatpp/web/app/Client.hpp"
+
+#include "oatpp/web/app/ControllerWithInterceptors.hpp"
+#include "oatpp/web/app/Controller.hpp"
+#include "oatpp/web/app/BasicAuthorizationController.hpp"
+#include "oatpp/web/app/BearerAuthorizationController.hpp"
+
+#include "oatpp/web/client/HttpRequestExecutor.hpp"
+
+#include "oatpp/web/server/HttpConnectionHandler.hpp"
+#include "oatpp/web/server/HttpRouter.hpp"
+
+#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+
+#include "oatpp/network/server/SimpleTCPConnectionProvider.hpp"
+#include "oatpp/network/client/SimpleTCPConnectionProvider.hpp"
+
+#include "oatpp/network/virtual_/client/ConnectionProvider.hpp"
+#include "oatpp/network/virtual_/server/ConnectionProvider.hpp"
+#include "oatpp/network/virtual_/Interface.hpp"
+
+#include "oatpp/network/ConnectionPool.hpp"
+
+#include "oatpp/core/macro/component.hpp"
+
+#include "oatpp-test/web/ClientServerTestRunner.hpp"
+#include "oatpp-test/Checker.hpp"
+
+namespace oatpp { namespace test { namespace web {
+
+namespace {
+
+typedef oatpp::web::server::api::ApiController ApiController;
+
+class TestServerComponent {
+private:
+  v_int32 m_port;
+public:
+
+  TestServerComponent(v_int32 port)
+    : m_port(port)
+  {}
+
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ServerConnectionProvider>, serverConnectionProvider)([this] {
+
+    if(m_port == 0) { // Use oatpp virtual interface
+      auto interface = oatpp::network::virtual_::Interface::obtainShared("virtualhost");
+      return std::static_pointer_cast<oatpp::network::ServerConnectionProvider>(
+        oatpp::network::virtual_::server::ConnectionProvider::createShared(interface)
+      );
+    }
+
+    return std::static_pointer_cast<oatpp::network::ServerConnectionProvider>(
+      oatpp::network::server::SimpleTCPConnectionProvider::createShared(m_port)
+    );
+
+  }());
+
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::web::server::HttpRouter>, httpRouter)([] {
+    return oatpp::web::server::HttpRouter::createShared();
+  }());
+
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::server::ConnectionHandler>, serverConnectionHandler)([] {
+    OATPP_COMPONENT(std::shared_ptr<oatpp::web::server::HttpRouter>, router);
+    return oatpp::web::server::HttpConnectionHandler::createShared(router);
+  }());
+
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::data::mapping::ObjectMapper>, objectMapper)([] {
+    return oatpp::parser::json::mapping::ObjectMapper::createShared();
+  }());
+
+};
+
+class TestClientComponent {
+private:
+  v_int32 m_port;
+public:
+
+  TestClientComponent(v_int32 port)
+    : m_port(port)
+  {}
+
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ClientConnectionProvider>, clientConnectionProvider)([this] {
+
+    if(m_port == 0) {
+      auto interface = oatpp::network::virtual_::Interface::obtainShared("virtualhost");
+      return std::static_pointer_cast<oatpp::network::ClientConnectionProvider>(
+        oatpp::network::virtual_::client::ConnectionProvider::createShared(interface)
+      );
+    }
+
+    return std::static_pointer_cast<oatpp::network::ClientConnectionProvider>(
+      oatpp::network::client::SimpleTCPConnectionProvider::createShared("127.0.0.1", m_port)
+    );
+
+  }());
+
+};
+
+void runServer(v_int32 port, v_int32 delaySeconds, v_int32 iterations, bool stable, const std::shared_ptr<app::Controller>& controller, bool wakeupServer) {
+
+  TestServerComponent component(port);
+
+  oatpp::test::web::ClientServerTestRunner runner;
+
+  runner.addController(controller);
+
+  runner.run([&runner, delaySeconds, iterations, stable, controller, wakeupServer] {
+
+    for(v_int32 i = 0; i < iterations; i ++) {
+      std::this_thread::sleep_for(std::chrono::seconds(delaySeconds));
+      if(!stable) {
+        controller->available = !controller->available;
+        OATPP_LOGI("Server", "Available=%d", (v_int32)controller->available.load());
+      }
+    }
+
+    if(wakeupServer) {
+
+      runner.getServer()->stop();
+      OATPP_COMPONENT(std::shared_ptr<oatpp::network::ClientConnectionProvider>, connectionProvider);
+      connectionProvider->getConnection();
+
+    }
+
+
+  }, std::chrono::minutes(10));
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+}
+
+}
+
+void ClientRetryTest::onRun() {
+
+  TestClientComponent component(m_port);
+
+  auto objectMapper = oatpp::parser::json::mapping::ObjectMapper::createShared();
+  auto controller = app::Controller::createShared(objectMapper);
+
+  OATPP_COMPONENT(std::shared_ptr<oatpp::network::ClientConnectionProvider>, connectionProvider);
+
+  {
+
+    OATPP_LOGI(TAG, "Test: no server available");
+    oatpp::test::PerformanceChecker checker("test: no server available");
+
+    auto retryPolicy = std::make_shared<oatpp::web::client::SimpleRetryPolicy>(2, std::chrono::seconds(1));
+    auto requestExecutor = oatpp::web::client::HttpRequestExecutor::createShared(connectionProvider, retryPolicy);
+    auto client = app::Client::createShared(requestExecutor, objectMapper);
+
+    auto response = client->getRoot();
+    auto ticks = checker.getElapsedTicks();
+
+    OATPP_LOGD(TAG, "ticks=%d", ticks);
+
+    if(m_port == 0) {
+
+      OATPP_ASSERT(response.get() == nullptr);
+      OATPP_ASSERT(ticks >= 2 * 1000 * 1000 /* 2s */);
+      OATPP_ASSERT(ticks < 3 * 1000 * 1000 /* 3s */);
+
+    } else {
+
+// TODO - investigate why it takes more than 2 seconds on windows to try to connect to unavailable host
+#if !defined(WIN32) && !defined(_WIN32)
+
+      OATPP_ASSERT(response.get() == nullptr);
+      OATPP_ASSERT(ticks >= 2 * 1000 * 1000 /* 2s */);
+      OATPP_ASSERT(ticks < 3 * 1000 * 1000 /* 3s */);
+
+#endif
+
+    }
+
+  }
+
+  {
+
+    OATPP_LOGI(TAG, "Test: server pops up");
+    oatpp::test::PerformanceChecker checker("test: server pops up");
+
+    auto retryPolicy = std::make_shared<oatpp::web::client::SimpleRetryPolicy>(10 * 10, std::chrono::milliseconds(100));
+    auto requestExecutor = oatpp::web::client::HttpRequestExecutor::createShared(connectionProvider, retryPolicy);
+    auto client = app::Client::createShared(requestExecutor, objectMapper);
+
+    std::list<std::thread> threads;
+
+    for(v_int32 i = 0; i < 100; i ++) {
+      threads.push_back(std::thread([client]{
+        auto response = client->getRoot();
+        OATPP_ASSERT(response);
+        OATPP_ASSERT(response->getStatusCode() == 200);
+        auto data = response->readBodyToString();
+        OATPP_ASSERT(data == "Hello World!!!");
+      }));
+    }
+
+    OATPP_LOGD(TAG, "Waiting for server to start...");
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    runServer(m_port, 1, 1, true, controller, true);
+
+    for(std::thread& thread : threads) {
+      thread.join();
+    }
+
+    auto ticks = checker.getElapsedTicks();
+    OATPP_ASSERT(ticks < 10 * 1000 * 1000 /* 10s */);
+
+  }
+
+  {
+
+    OATPP_LOGI(TAG, "Test: unstable server!");
+
+    auto retryPolicy = std::make_shared<oatpp::web::client::SimpleRetryPolicy>(-1, std::chrono::seconds(1));
+    auto connectionPool = std::make_shared<oatpp::network::ClientConnectionPool>(connectionProvider, 10, std::chrono::seconds(1));
+    auto requestExecutor = oatpp::web::client::HttpRequestExecutor::createShared(connectionPool, retryPolicy);
+    auto client = app::Client::createShared(requestExecutor, objectMapper);
+
+    std::list<std::thread> threads;
+    std::atomic<bool> testIsRunning(true);
+
+    std::thread clientThread([client, &testIsRunning]{
+
+      v_int64 counter = 0;
+
+      v_int64 tick0 = oatpp::base::Environment::getMicroTickCount();
+
+      while(oatpp::base::Environment::getMicroTickCount() - tick0 < 10 * 1000 * 1000) {
+
+        auto response = client->getAvailability();
+        OATPP_ASSERT(response);
+        OATPP_ASSERT(response->getStatusCode() == 200);
+        auto data = response->readBodyToString();
+        OATPP_ASSERT(data == "Hello World!!!");
+        counter ++;
+
+        if(counter % 1000 == 0) {
+          OATPP_LOGD("client", "requests=%d", counter);
+        }
+
+      }
+
+    });
+
+    runServer(m_port, 2, 6, false, controller, true);
+
+    clientThread.join();
+
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(2)); // wait connection pool.
+
+}
+
+}}}

--- a/test/oatpp/web/ClientRetryTest.hpp
+++ b/test/oatpp/web/ClientRetryTest.hpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_web_ClientRetryTest_hpp
+#define oatpp_test_web_ClientRetryTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace web {
+
+class ClientRetryTest : public UnitTest {
+private:
+  v_int32 m_port;
+public:
+
+  ClientRetryTest(v_int32 port)
+    : UnitTest("TEST[web::ClientRetryTest]")
+    , m_port(port)
+  {}
+
+  void onRun() override;
+
+};
+
+}}}
+
+#endif /* oatpp_test_web_ClientRetryTest_hpp */

--- a/test/oatpp/web/app/Client.hpp
+++ b/test/oatpp/web/app/Client.hpp
@@ -42,6 +42,7 @@ public:
   API_CLIENT_INIT(Client)
   
   API_CALL("GET", "/", getRoot)
+  API_CALL("GET", "/availability", getAvailability)
   API_CALL("GET", "/cors", getCors)
   API_CALL("OPTIONS", "/cors", optionsCors)
   API_CALL("GET", "/cors-origin", getCorsOrigin)

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -177,7 +177,7 @@ public:
       , m_iterations(iterations)
     {}
 
-    data::v_io_size read(void *buffer, data::v_io_size count) override {
+    data::v_io_size read(void *buffer, v_buff_size count) override {
       (void)count;
       if(m_counter < m_iterations) {
         std::memcpy(buffer, m_text->getData(), m_text->getSize());

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -46,24 +46,35 @@ namespace oatpp { namespace test { namespace web { namespace app {
 
 namespace multipart = oatpp::web::mime::multipart;
 
+#include OATPP_CODEGEN_BEGIN(ApiController)
+
 class Controller : public oatpp::web::server::api::ApiController {
 private:
   static constexpr const char* TAG = "test::web::app::Controller";
 public:
   Controller(const std::shared_ptr<ObjectMapper>& objectMapper)
     : oatpp::web::server::api::ApiController(objectMapper)
+    , available(true)
   {}
 public:
   
   static std::shared_ptr<Controller> createShared(const std::shared_ptr<ObjectMapper>& objectMapper = OATPP_GET_COMPONENT(std::shared_ptr<ObjectMapper>)){
     return std::make_shared<Controller>(objectMapper);
   }
-  
-#include OATPP_CODEGEN_BEGIN(ApiController)
+
+  std::atomic<bool> available;
 
   ENDPOINT("GET", "/", root) {
-    //OATPP_LOGV(TAG, "GET '/'");
     return createResponse(Status::CODE_200, "Hello World!!!");
+  }
+
+  ENDPOINT("GET", "/availability", availability) {
+    //OATPP_LOGV(TAG, "GET '/availability'");
+    if(available) {
+      return createResponse(Status::CODE_200, "Hello World!!!");
+    }
+    OATPP_LOGI(TAG, "GET '/availability'. Service unavailable.");
+    OATPP_ASSERT_HTTP(false, Status::CODE_503, "Service unavailable")
   }
 
   ADD_CORS(cors);
@@ -250,10 +261,10 @@ public:
     return createResponse(Status::CODE_200, "OK");
 
   }
-
-#include OATPP_CODEGEN_END(ApiController)
   
 };
+
+#include OATPP_CODEGEN_END(ApiController)
 
 }}}}
 


### PR DESCRIPTION
Summary:
- Merged the latest changes from oatpp master.
- Introduced `v_buff_size` data type as an integer capable of storing the pointer.
- Moved String and buffers to `v_buff_size` for their sizes.
